### PR TITLE
Add Direct to G7 prototype using DexcomKit

### DIFF
--- a/Luka.xcodeproj/project.pbxproj
+++ b/Luka.xcodeproj/project.pbxproj
@@ -1152,7 +1152,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kylebshr/DexcomKit";
 			requirement = {
-				branch = "claude/dexcomkit-luka-prototype-37ulik";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Luka.xcodeproj/project.pbxproj
+++ b/Luka.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		27834B8A2ECF81A70096D201 /* TelemetryDeck in Frameworks */ = {isa = PBXBuildFile; productRef = 27834B892ECF81A70096D201 /* TelemetryDeck */; };
 		27BA04A52ED239210096F131 /* TelemetryDeck in Frameworks */ = {isa = PBXBuildFile; productRef = 27BA04A42ED239210096F131 /* TelemetryDeck */; };
 		27C6E25F2BCF386E006BAE98 /* Dexcom in Frameworks */ = {isa = PBXBuildFile; productRef = 27C6E25E2BCF386E006BAE98 /* Dexcom */; };
+		27D3C0DE2F5A000000000003 /* DexcomKit in Frameworks */ = {isa = PBXBuildFile; productRef = 27D3C0DE2F5A000000000002 /* DexcomKit */; };
 		27C6E2622BCF387A006BAE98 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 27C6E2612BCF387A006BAE98 /* KeychainAccess */; };
 		27DB8CB72E9DE3C0005B8087 /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = 27DB8CB62E9DE3C0005B8087 /* Defaults */; };
 		27DB8CB92E9DE3CB005B8087 /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = 27DB8CB82E9DE3CB005B8087 /* Defaults */; };
@@ -344,6 +345,7 @@
 				27DB9A012EA2048C005B8087 /* ActivityKit.framework in Frameworks */,
 				27834B8A2ECF81A70096D201 /* TelemetryDeck in Frameworks */,
 				27C6E25F2BCF386E006BAE98 /* Dexcom in Frameworks */,
+				27D3C0DE2F5A000000000003 /* DexcomKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -515,6 +517,7 @@
 				27C6E2612BCF387A006BAE98 /* KeychainAccess */,
 				27DB8CB62E9DE3C0005B8087 /* Defaults */,
 				27834B892ECF81A70096D201 /* TelemetryDeck */,
+				27D3C0DE2F5A000000000002 /* DexcomKit */,
 			);
 			productName = Glimpse;
 			productReference = 27F577672BCF38330012D66C /* Luka.app */;
@@ -567,6 +570,7 @@
 				27C6E2602BCF387A006BAE98 /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 				27DB8CB52E9DE3C0005B8087 /* XCRemoteSwiftPackageReference "Defaults" */,
 				27834B882ECF81A70096D201 /* XCRemoteSwiftPackageReference "SwiftSDK" */,
+				27D3C0DE2F5A000000000001 /* XCRemoteSwiftPackageReference "DexcomKit" */,
 			);
 			productRefGroup = 27F577682BCF38330012D66C /* Products */;
 			projectDirPath = "";
@@ -1144,6 +1148,14 @@
 				minimumVersion = 2.9.10;
 			};
 		};
+		27D3C0DE2F5A000000000001 /* XCRemoteSwiftPackageReference "DexcomKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kylebshr/DexcomKit";
+			requirement = {
+				branch = "claude/dexcomkit-luka-prototype-37ulik";
+				kind = branch;
+			};
+		};
 		27C6E25D2BCF386E006BAE98 /* XCRemoteSwiftPackageReference "dexcom-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kylebshr/dexcom-swift";
@@ -1171,6 +1183,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		27D3C0DE2F5A000000000002 /* DexcomKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 27D3C0DE2F5A000000000001 /* XCRemoteSwiftPackageReference "DexcomKit" */;
+			productName = DexcomKit;
+		};
 		270332622BD9A09F009535EE /* Dexcom */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 27C6E25D2BCF386E006BAE98 /* XCRemoteSwiftPackageReference "dexcom-swift" */;

--- a/Luka/DirectToG7Manager.swift
+++ b/Luka/DirectToG7Manager.swift
@@ -1,0 +1,74 @@
+//
+//  DirectToG7Manager.swift
+//  Luka
+//
+//  Created by Claude on 7/6/26.
+//
+
+import Defaults
+import DexcomKit
+import Foundation
+import TelemetryDeck
+
+/// Prototype: follows a Dexcom G7 sensor directly over Bluetooth via
+/// DexcomKit, riding alongside the official Dexcom app's session.
+@MainActor @Observable final class DirectToG7Manager {
+    static let shared = DirectToG7Manager()
+
+    /// The active monitor; non-nil while Direct to G7 is enabled.
+    private(set) var monitor: G7SensorMonitor?
+
+    /// Mirrors `Defaults[.directToG7Enabled]`; setting it starts or stops
+    /// following the sensor.
+    var isEnabled: Bool {
+        didSet {
+            guard isEnabled != oldValue else { return }
+            Defaults[.directToG7Enabled] = isEnabled
+            TelemetryDeck.signal(isEnabled ? "DirectToG7.enabled" : "DirectToG7.disabled")
+
+            if isEnabled {
+                start()
+            } else {
+                stop()
+            }
+        }
+    }
+
+    private init() {
+        isEnabled = Defaults[.directToG7Enabled]
+    }
+
+    /// Resumes following at launch — including background relaunches for
+    /// Bluetooth state restoration — when the setting is on.
+    func syncState() {
+        if isEnabled {
+            start()
+        }
+    }
+
+    /// Forgets the followed sensor so the next scan adopts fresh.
+    func forgetSensor() {
+        monitor?.forgetSensor()
+    }
+
+    private func start() {
+        guard monitor == nil else { return }
+
+        let monitor = G7SensorMonitor(
+            configuration: G7Configuration(
+                store: UserDefaultsStore(suiteName: "group.com.kylebashour.Glimpse"),
+                restoreIdentifier: "com.kylebashour.Glimpse.dexcomkit"
+            )
+        )
+
+        // With the default `.automatic` selection, `start()` has no failure
+        // cases; if that ever changes, fail quietly rather than crash.
+        try? monitor.start()
+        self.monitor = monitor
+    }
+
+    private func stop() {
+        monitor?.stop()
+        monitor = nil
+    }
+}

--- a/Luka/Info.plist
+++ b/Luka/Info.plist
@@ -4,9 +4,15 @@
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Luka can connect directly to your Dexcom G7 sensor to show its readings.</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>bluetooth-central</string>
+	</array>
 </dict>
 </plist>

--- a/Luka/LukaApp.swift
+++ b/Luka/LukaApp.swift
@@ -34,6 +34,10 @@ struct LukaApp: App {
 
         // Increment launch count
         Defaults[.launchCount] += 1
+
+        // Resume Direct to G7 following if enabled, including background
+        // relaunches for Bluetooth state restoration.
+        DirectToG7Manager.shared.syncState()
     }
 
     var body: some Scene {

--- a/Luka/Views/DirectToG7View.swift
+++ b/Luka/Views/DirectToG7View.swift
@@ -46,13 +46,15 @@ struct DirectToG7View: View {
                     }
                 }
 
-                Section("Latest reading") {
+                Section {
                     if let reading = monitor.latestReading {
                         readingRow(reading)
                     } else {
                         Text("Waiting for a reading…")
                             .foregroundStyle(.secondary)
                     }
+                } header: {
+                    Text("Latest reading")
                 } footer: {
                     Text("The sensor sends a new reading about every five minutes, and backfills readings missed while out of range.")
                 }

--- a/Luka/Views/DirectToG7View.swift
+++ b/Luka/Views/DirectToG7View.swift
@@ -1,0 +1,174 @@
+//
+//  DirectToG7View.swift
+//  Luka
+//
+//  Created by Claude on 7/6/26.
+//
+
+import Defaults
+import Dexcom
+import DexcomKit
+import SwiftUI
+
+struct DirectToG7View: View {
+    @Default(.unit) private var unit
+    @Default(.targetRangeLowerBound) private var lowerTargetRange
+    @Default(.targetRangeUpperBound) private var upperTargetRange
+
+    var body: some View {
+        @Bindable var manager = DirectToG7Manager.shared
+
+        List {
+            Section {
+                Toggle("Direct to G7", isOn: $manager.isEnabled)
+                    .tint(.accent)
+            } footer: {
+                Text("Listen to your G7 directly over Bluetooth, alongside the Dexcom app. The sensor must already be running a session with the Dexcom app on this phone.")
+            }
+
+            if let monitor = manager.monitor {
+                Section("Connection") {
+                    LabeledContent("Status") {
+                        HStack(spacing: .spacing4) {
+                            Circle()
+                                .fill(monitor.connectionState.indicatorColor)
+                                .frame(width: 8, height: 8)
+                            Text(monitor.connectionState.text)
+                        }
+                    }
+
+                    if let session = monitor.session {
+                        LabeledContent("Sensor", value: session.sensorName)
+                        LabeledContent(
+                            "Expires",
+                            value: session.expirationDate.formatted(date: .abbreviated, time: .shortened)
+                        )
+                    }
+                }
+
+                Section("Latest reading") {
+                    if let reading = monitor.latestReading {
+                        readingRow(reading)
+                    } else {
+                        Text("Waiting for a reading…")
+                            .foregroundStyle(.secondary)
+                    }
+                } footer: {
+                    Text("The sensor sends a new reading about every five minutes, and backfills readings missed while out of range.")
+                }
+
+                Section {
+                    Button("Forget sensor", role: .destructive) {
+                        manager.forgetSensor()
+                    }
+                } footer: {
+                    Text("Forget the followed sensor so the next scan can adopt a new one, for example after replacing a sensor early.")
+                }
+            }
+        }
+        .animation(.default, value: manager.isEnabled)
+        .listStyle(.insetGrouped)
+        .navigationTitle("Direct to G7")
+        .fontDesign(.rounded)
+    }
+
+    private func readingRow(_ reading: DexcomKit.GlucoseReading) -> some View {
+        HStack {
+            HStack(spacing: .spacing4) {
+                if let glucose = reading.glucose {
+                    Text(glucose.formatted(.glucose(unit)))
+                        .foregroundStyle(color(for: glucose))
+
+                    reading.trendArrow?.image
+                } else {
+                    Text(verbatim: "—")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .fontWeight(.semibold)
+
+            Spacer()
+
+            Text(reading.date, style: .relative)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func color(for glucose: Int) -> Color {
+        // Integer-truncated bounds, consistent with GlucoseReading.color(target:).
+        if glucose < Int(lowerTargetRange) {
+            .lowColor
+        } else if glucose > Int(upperTargetRange) {
+            .highColor
+        } else {
+            .inRangeColor
+        }
+    }
+}
+
+private extension G7ConnectionState {
+    var text: LocalizedStringKey {
+        switch self {
+        case .idle:
+            "Off"
+        case .bluetoothUnavailable(.poweredOff):
+            "Bluetooth is off"
+        case .bluetoothUnavailable(.unauthorized):
+            "Bluetooth not allowed"
+        case .bluetoothUnavailable(.unsupported):
+            "Bluetooth unsupported"
+        case .bluetoothUnavailable(.resetting), .bluetoothUnavailable(.unknown):
+            "Bluetooth unavailable"
+        case .scanning:
+            "Scanning"
+        case .connecting:
+            "Connecting"
+        case .authenticating:
+            "Authenticating"
+        case .connected:
+            "Connected"
+        case .waitingForReading:
+            "Waiting for next reading"
+        }
+    }
+
+    var indicatorColor: Color {
+        switch self {
+        case .idle:
+            .gray
+        case .bluetoothUnavailable:
+            .lowColor
+        case .scanning, .connecting, .authenticating:
+            .highColor
+        case .connected, .waitingForReading:
+            .inRangeColor
+        }
+    }
+}
+
+private extension DexcomKit.TrendArrow {
+    var image: Image {
+        switch self {
+        case .fallingQuickly:
+            Image("arrow.down.double")
+        case .falling:
+            Image(systemName: "arrow.down")
+        case .fallingSlightly:
+            Image(systemName: "arrow.down.right")
+        case .steady:
+            Image(systemName: "arrow.right")
+        case .risingSlightly:
+            Image(systemName: "arrow.up.right")
+        case .rising:
+            Image(systemName: "arrow.up")
+        case .risingQuickly:
+            Image("arrow.up.double")
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DirectToG7View()
+    }
+}

--- a/Luka/Views/SettingsView.swift
+++ b/Luka/Views/SettingsView.swift
@@ -131,6 +131,17 @@ struct SettingsView: View {
 
             Section {
                 NavigationLink {
+                    DirectToG7View()
+                } label: {
+                    Text("Direct to G7")
+                }
+            } footer: {
+                Text("An early prototype of connecting directly to your G7 over Bluetooth.")
+            }
+            .fontWeight(.medium)
+
+            Section {
+                NavigationLink {
                     ExperimentalView()
                 } label: {
                     Text("Advanced")

--- a/Shared/Utilities/Defaults.swift
+++ b/Shared/Utilities/Defaults.swift
@@ -45,6 +45,8 @@ extension Defaults.Keys {
     // not leak to another device. Persisted so a token rotation that background-relaunches
     // the app can still hand it to the server before the PTS stream re-yields.
     static let pushToStartToken = Key<String?>("pushToStartToken", default: nil, suite: .shared)
+    // Device-local: following a sensor over Bluetooth is inherently per-device.
+    static let directToG7Enabled = Key<Bool>("directToG7Enabled", default: false, suite: .shared)
 }
 
 extension AccountLocation: Defaults.Serializable {}


### PR DESCRIPTION
## Summary

Adds a prototype **Direct to G7** setting that follows a Dexcom G7 sensor directly over Bluetooth via the new [DexcomKit](https://github.com/kylebshr/DexcomKit) package, riding alongside the official Dexcom app's session.

- New **Direct to G7** row in Settings (above Advanced) drills into a screen with:
  - A toggle to enable/disable following
  - Live connection status (scanning / connecting / authenticating / connected / waiting for next reading / Bluetooth unavailable) plus the followed sensor's name and expiration once a session is adopted
  - The latest reading with unit formatting, target-range color coding, trend arrow, and an auto-updating relative timestamp
  - A **Forget sensor** button for early replacements or wrong-sensor adoption
- `DirectToG7Manager` (`@MainActor @Observable` singleton) owns the `G7SensorMonitor` lifecycle, persists the setting in the shared defaults suite (device-local, not iCloud-synced), and resumes following at launch so CoreBluetooth state-restoration relaunches keep working
- DexcomKit is linked to the iOS app target only, pinned to `main`
- Adds `NSBluetoothAlwaysUsageDescription` and the `bluetooth-central` background mode to the app's Info.plist

## Testing

- CI (build) is green
- On-device validation requires a G7 running a session with the official Dexcom app on the same phone — the follower flow can't be exercised in CI or the simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqrWaZUN1tSJJpgHGEZhbz

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqrWaZUN1tSJJpgHGEZhbz)_