### PR TITLE
Add bottom glow to Live Activity, drop small layout background tint

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -272,6 +272,9 @@ private struct MainContentView: View {
                 .multilineTextAlignment(.trailing)
                 .layoutPriority(10)
             }
+            // Fill the cell so the bottom glow reaches the bottom edge — the
+            // removed tinted rectangle used to be what stretched this layout.
+            .frame(maxHeight: .infinity)
             .padding(10)
         }
     }

--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -21,6 +21,13 @@ struct ReadingActivityConfiguration: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: ReadingAttributes.self) { context in
             MainContentView(context: context)
+                .background {
+                    // Applied outside the content's padding so the glow bleeds
+                    // all the way to the card's edges instead of being inset.
+                    if !context.isOffline, let color = context.state.c?.vividColor(target: targetLower...targetUpper) {
+                        bottomGlow(color: color)
+                    }
+                }
                 .widgetURL(tapApp.url)
         } dynamicIsland: { context in
             return DynamicIsland {
@@ -75,6 +82,23 @@ struct ReadingActivityConfiguration: Widget {
             .widgetURL(tapApp.url)
         }
         .supplementalActivityFamilies([.small])
+    }
+
+    /// A soft bloom of the reading's color rising from the bottom edge, meant to
+    /// sit behind everything else via `.background`. Kept subtle — the activity
+    /// renders on a near-black background, so a strong tint would fight with the
+    /// content on top of it.
+    @ViewBuilder func bottomGlow(color: Color) -> some View {
+        EllipticalGradient(
+            colors: [color.opacity(0.35), .clear],
+            center: .bottom,
+            startRadiusFraction: 0,
+            endRadiusFraction: 0.65
+        )
+        // Stretch the bloom horizontally so it washes across the full bottom
+        // edge instead of pooling in the center.
+        .scaleEffect(x: 1.5, anchor: .bottom)
+        .allowsHitTesting(false)
     }
 }
 
@@ -198,8 +222,6 @@ private struct MainContentView: View {
     var context: ActivityViewContext<ReadingAttributes>
 
     @Environment(\.activityFamily) private var family
-    @Default(.targetRangeLowerBound) private var targetLower
-    @Default(.targetRangeUpperBound) private var targetUpper
     @Default(.showChartLiveActivity) private var _showChartLiveActivity
     @Default(.debugInfo) private var debugInfo
 
@@ -219,46 +241,38 @@ private struct MainContentView: View {
         if context.isExpired == true {
             smallExpiredView()
         } else {
-            ZStack {
-                if !context.isOffline, let color = context.state.c?.vividColor(target: targetLower...targetUpper) {
-                    Rectangle()
-                        .fill(color)
-                        .brightness(-0.6)
-                        .opacity(0.37)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
+            // No tinted background here — the bottom glow behind the whole
+            // activity carries the reading's color instead.
+            HStack(spacing: 0) {
+                ReadingView(reading: context.state.c)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .font(.title.weight(.regular))
+                    .layoutPriority(100)
+                    .opacity(context.isOffline ? 0.5 : 1)
 
-                HStack(spacing: 0) {
-                    ReadingView(reading: context.state.c)
-                        .fixedSize(horizontal: true, vertical: false)
-                        .font(.title.weight(.regular))
-                        .layoutPriority(100)
-                        .opacity(context.isOffline ? 0.5 : 1)
+                Spacer(minLength: 2)
 
-                    Spacer(minLength: 2)
+                VStack(alignment: .trailing, spacing: 0) {
+                    MinuteTimerView(context: context, relative: false)
+                        .lineLimit(1)
+                        .font(.footnote.bold())
 
-                    VStack(alignment: .trailing, spacing: 0) {
-                        MinuteTimerView(context: context, relative: false)
-                            .lineLimit(1)
-                            .font(.footnote.bold())
-
-                        if #available(iOS 26, *) {
-                            if let reason = context.state.r {
-                                Text(verbatim: reason)
-                                    .font(.footnote.bold())
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(2)
-                                    .fixedSize(horizontal: false, vertical: true)
-                                    .lineHeight(.tight)
-                            }
+                    if #available(iOS 26, *) {
+                        if let reason = context.state.r {
+                            Text(verbatim: reason)
+                                .font(.footnote.bold())
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .lineHeight(.tight)
                         }
                     }
-                    .minimumScaleFactor(0.5)
-                    .multilineTextAlignment(.trailing)
-                    .layoutPriority(10)
                 }
-                .padding(10)
+                .minimumScaleFactor(0.5)
+                .multilineTextAlignment(.trailing)
+                .layoutPriority(10)
             }
+            .padding(10)
         }
     }
 


### PR DESCRIPTION
Ports Paku's Live Activity glow styling into Luka.

## What changed

- **Bottom glow** — a soft `EllipticalGradient` bloom of the reading's color rising from the bottom edge, stretched 1.5× horizontally so it washes across the full width. Applied via `.background` on the content (outside its padding, so it bleeds to the card's edges), it covers both the small and medium activity families — the same approach Paku uses.
- **Small layout** — removed the solid tinted `Rectangle` background in favor of the glow, collapsing the now-redundant `ZStack` to a plain `HStack`.
- Removed two now-unused `@Default` target-bound properties from `MainContentView` (they only fed the removed rectangle).

## Notes

- The glow uses the existing `vividColor(target:)` (pure red/green/yellow) rather than `color(target:)`. Per the existing comment on `vividColor`, the global low/inRange/high colors wash out at low opacity over a dark background — and the glow renders at 0.35 opacity on a near-black background. It's also the direct analog to Paku's use of its vivid chart color.
- Built and reviewed on Linux (no Xcode available), so this wasn't compiled or previewed. The `#Preview("Content", …)` block renders both the small and medium glow for a visual check in the Xcode canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzU36k3qLk3djD4AURU3Nr

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzU36k3qLk3djD4AURU3Nr)_