### PR TITLE
Remove blurred glow chart behind Live Activity graph

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -418,24 +418,12 @@ private struct GraphPieceView: View {
     var context: ActivityViewContext<ReadingAttributes>
 
     var body: some View {
-        ZStack {
-            LineChart(
-                range: context.attributes.range,
-                style: .line,
-                readings: context.state.h,
-                lineWidth: 15
-            )
-            .saturation(2)
-            .blur(radius: 30)
-            .opacity(0.85)
-
-            LineChart(
-                range: context.attributes.range,
-                style: Defaults[.liveActivityGraphStyle],
-                readings: context.state.h
-            )
-            .padding(.trailing)
-        }
+        LineChart(
+            range: context.attributes.range,
+            style: Defaults[.liveActivityGraphStyle],
+            readings: context.state.h
+        )
+        .padding(.trailing)
         .padding(.leading, -5)
         .frame(maxHeight: family == .medium ? 70 : nil)
     }


### PR DESCRIPTION
Drops the stacked, saturated, blurred `LineChart` that sat behind the graph line in the Live Activity to fake a glow. Just the real chart remains.

## What changed

- In `GraphPieceView`, removed the second `LineChart` (`.saturation(2).blur(radius: 30).opacity(0.85)`) rendered behind the real one, and collapsed the now single-child `ZStack`.
- Kept the real chart's exact padding and frame, so the graph itself doesn't shift.

## Notes

- Built and reviewed on Linux (no Xcode available), so this wasn't compiled or previewed. The `#Preview("Content", …)` block renders the graph for a visual check in the Xcode canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzU36k3qLk3djD4AURU3Nr

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzU36k3qLk3djD4AURU3Nr)_