### PR TITLE
Add delta to medium Live Activity and increase chart height

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -287,10 +287,15 @@ private struct MainContentView: View {
         } else {
             VStack(spacing: 0) {
                 HStack {
-                    ReadingView(reading: context.state.c)
-                        .font(.largeTitle)
-                        .fontDesign(.rounded)
-                        .opacity(context.isOffline ? 0.5 : 1)
+                    HStack(spacing: .spacing3) {
+                        ReadingView(reading: context.state.c)
+
+                        DeltaText(context: context)
+                            .foregroundStyle(.secondary)
+                    }
+                    .font(.largeTitle)
+                    .fontDesign(.rounded)
+                    .opacity(context.isOffline ? 0.5 : 1)
 
                     Spacer()
 
@@ -397,6 +402,20 @@ private struct MediumExpiredView: View {
     }
 }
 
+/// The change since the previous reading, e.g. "+5" or "-10".
+private struct DeltaText: View {
+    @Default(.unit) private var unit
+    var context: ActivityViewContext<ReadingAttributes>
+
+    var body: some View {
+        if let delta = context.delta {
+            Text(verbatim: (delta < 0 ? "-" : "+") + abs(delta).formatted(.glucose(unit)))
+                .lowercaseSmallCaps()
+                .contentTransition(.numericText(value: Double(delta)))
+        }
+    }
+}
+
 private struct WithRange<Content: View>: View {
     @Default(.targetRangeLowerBound) private var targetLower
     @Default(.targetRangeUpperBound) private var targetUpper
@@ -426,7 +445,7 @@ private struct GraphPieceView: View {
         )
         .padding(.trailing)
         .padding(.leading, -5)
-        .frame(maxHeight: family == .medium ? 60 : nil)
+        .frame(maxHeight: family == .medium ? 65 : nil)
     }
 }
 
@@ -444,6 +463,17 @@ private extension ActivityViewContext<ReadingAttributes> {
 
     var isExpired: Bool {
         state.se ?? (state.c == nil)
+    }
+
+    /// Change from the previous reading, in mg/dL. Nil when there's no current
+    /// reading or no preceding history entry, or when the gap between them is
+    /// too large (a sensor dropout) for the difference to be meaningful.
+    var delta: Int? {
+        guard let current = state.c,
+              let previous = state.h.last(where: { $0.t < current.date }),
+              current.date.timeIntervalSince(previous.t) <= 15 * 60
+        else { return nil }
+        return current.value - Int(previous.v)
     }
 
     var timestampColor: Color {


### PR DESCRIPTION
## Summary

- Show the change since the previous reading (e.g. `+5` or `-10`) after the reading arrow on the medium Live Activity presentation, in the same large rounded font as the reading but with secondary styling
- Increase the medium Live Activity chart's max height from 60 to 65 points

## Details

- New `DeltaText` view sits in the same `HStack` as `ReadingView`, sharing its `.largeTitle` rounded font and small-caps treatment, with a numeric content transition; it dims with the reading when offline
- The delta is computed on the activity context as the current value minus the most recent history entry before it, and hides itself when there's no current reading, no preceding history entry, or the previous reading is more than 15 minutes old (a sensor dropout gap where the difference would be misleading)
- The difference is formatted through the same `.glucose(unit)` style as readings, which stays correct for mmol/L since the unit conversion is linear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNTjQhXfymtoDuao9h1SGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNTjQhXfymtoDuao9h1SGA)_