### PR TITLE
Use title2 for small Live Activity reading and delta

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -252,10 +252,9 @@ private struct MainContentView: View {
                     Text(" ")
                     DeltaText(context: context)
                         .foregroundStyle(.secondary)
-                        .font(.title.weight(.regular).width(.compressed))
                 }
                 .fixedSize(horizontal: true, vertical: false)
-                .font(.title.weight(.regular).width(.compressed))
+                .font(.title2.weight(.regular))
                 .layoutPriority(100)
                 .opacity(context.isOffline ? 0.5 : 1)
 


### PR DESCRIPTION
Shrinks the reading + delta in the small (Smart Stack) Live Activity content view from `.title` to `.title2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSpR95zht9S2NdEBSZtoSw