### PR TITLE
Move delta under the timestamp in the small Live Activity

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -249,7 +249,7 @@ private struct MainContentView: View {
             HStack(spacing: 0) {
                 ReadingView(reading: context.state.c)
                     .fixedSize(horizontal: true, vertical: false)
-                    .font(.title)
+                    .font(.title.weight(.regular))
                     .layoutPriority(100)
                     .opacity(context.isOffline ? 0.5 : 1)
 

--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -247,35 +247,32 @@ private struct MainContentView: View {
             // No tinted background here — the bottom glow behind the whole
             // activity carries the reading's color instead.
             HStack(spacing: 0) {
-                HStack(spacing: 0) {
-                    ReadingView(reading: context.state.c)
-                    Text(" ")
-                    DeltaText(context: context)
-                        .foregroundStyle(.secondary)
-                }
-                .fixedSize(horizontal: true, vertical: false)
-                .font(.title2.weight(.regular))
-                .layoutPriority(100)
-                .opacity(context.isOffline ? 0.5 : 1)
+                ReadingView(reading: context.state.c)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .font(.title)
+                    .layoutPriority(100)
+                    .opacity(context.isOffline ? 0.5 : 1)
 
                 Spacer(minLength: 2)
 
                 VStack(alignment: .trailing, spacing: 0) {
                     MinuteTimerView(context: context, relative: false)
                         .lineLimit(1)
-                        .font(.footnote.bold())
 
-                    if #available(iOS 26, *) {
-                        if let reason = context.state.r {
+                    if let reason = context.state.r {
+                        if #available(iOS 26, *) {
                             Text(verbatim: reason)
-                                .font(.footnote.bold())
                                 .foregroundStyle(.secondary)
                                 .lineLimit(2)
                                 .fixedSize(horizontal: false, vertical: true)
-                                .lineHeight(.tight)
                         }
+                    } else {
+                        DeltaText(context: context)
+                            .foregroundStyle(.secondary)
                     }
                 }
+                .font(.footnote.bold())
+                .tightLineHeight()
                 .minimumScaleFactor(0.5)
                 .multilineTextAlignment(.trailing)
                 .layoutPriority(10)
@@ -422,6 +419,18 @@ private struct DeltaText: View {
             ))
             .lowercaseSmallCaps()
             .contentTransition(.numericText(value: Double(delta)))
+        }
+    }
+}
+
+private extension View {
+    /// `.lineHeight(.tight)` where it exists, so the stacked timestamp, delta,
+    /// and reason lines sit close together instead of drifting apart.
+    @ViewBuilder func tightLineHeight() -> some View {
+        if #available(iOS 26, *) {
+            lineHeight(.tight)
+        } else {
+            self
         }
     }
 }


### PR DESCRIPTION
Reworks the small Live Activity content view's layout.

- The delta moves out of the reading's `HStack` and into the trailing `VStack`, directly beneath the timestamp.
- It only shows when there's no reason message — the reason branch now has an `else` carrying `DeltaText`, with the reason keeping its existing iOS 26 gate nested inside.
- Timestamp, delta, and reason share one `.font(.footnote.bold())`, hoisted to the stack, and the delta picks up `.secondary` to match the reason message.
- The reading is now `.title.weight(.regular)` (was `.title2`).
- `.lineHeight(.tight)` moves off the reason `Text` and onto the whole stack via a new `tightLineHeight()` helper that no-ops below iOS 26, so every line gets it. The stack was already `spacing: 0`.

Not compile-verified — no Swift toolchain in the environment this was written in, so it's worth a build in Xcode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZADrtbk5PAGhD5bXHkzXM)_