### PR TITLE
Add optional supporter subscriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,26 @@ struct GraphWidgetConfiguration: WidgetConfigurationIntent {
 - **Compact**: Leading (value) + Trailing (arrow)
 - **Minimal**: Compressed glucose display
 
+## Supporter Subscription (IAP)
+
+Optional monthly tip-jar subscriptions that help pay for the Live Activity server. They unlock nothing.
+
+| Tier | Product ID | Price | ASC ID |
+|------|------------|-------|--------|
+| Glucose Tab | `com.kylebashour.Glimpse.supporter.monthly` | $1.99/mo | 6809558033 |
+| Juice Box | `com.kylebashour.Glimpse.supporter.super.monthly` | $4.99/mo | 6809559490 |
+| The Whole Fridge | `com.kylebashour.Glimpse.supporter.mega.monthly` | $9.99/mo | 6809559702 |
+
+All three live in subscription group 22366942 ("Supporter"), The Whole Fridge at group level 1, so switching tiers is an upgrade/downgrade.
+
+- `Luka/Store/SupporterStore.swift` - `SupporterTier` enum and the `@Observable` StoreKit 2 store (products, entitlement, purchase, restore). Injected via `.environment(supporterStore)` from `LukaApp`.
+- `Luka/Store/SupportPrompt.swift` - pure logic for when to prompt after a Live Activity start (2nd start onward, at most every 30 days, never for supporters). Tested in `LukaTests`.
+- `Luka/Views/SupportView.swift` - the sheet (tier picker, purchase, restore, manage subscription, Terms/Privacy links).
+- `Luka/Views/SupportBannerView.swift` - promo under the Live Activity button; hidden for supporters or once dismissed.
+- Settings has a "Support" section; `StartLiveActivityIntent` increments `Defaults[.liveActivityStartCount]`.
+- `Luka/Luka.storekit` is attached to the Luka scheme for local StoreKit testing and excluded from the app bundle.
+- Manage in App Store Connect with `asc subscriptions ...` (app ID 6499279663).
+
 ## API Integration
 
 ### Dexcom API

--- a/Luka.xcodeproj/project.pbxproj
+++ b/Luka.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
+				Luka.storekit,
 			);
 			target = 27F577662BCF38330012D66C /* Luka */;
 		};
@@ -264,6 +265,7 @@
 				Views/Form/FormSectionDivider.swift,
 				Views/RootViewModel.swift,
 				Views/SignInView.swift,
+				Luka.storekit,
 			);
 			target = 2741EA0E2BD8AEBA003EDEB2 /* Watch */;
 		};

--- a/Luka.xcodeproj/xcshareddata/xcschemes/Luka.xcscheme
+++ b/Luka.xcodeproj/xcshareddata/xcschemes/Luka.xcscheme
@@ -64,6 +64,9 @@
             ReferencedContainer = "container:Luka.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../../Luka/Luka.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Luka/Luka.storekit
+++ b/Luka/Luka.storekit
@@ -1,0 +1,99 @@
+{
+  "identifier": "A5F0C1D2-7B3E-4E1A-9C2D-1E2F3A4B5C6D",
+  "nonRenewingSubscriptions": [],
+  "products": [],
+  "settings": {
+    "_applicationInternalID": "6499279663",
+    "_developerTeamID": "ZEAD23GG77",
+    "_failTransactionsEnabled": false,
+    "_lastSynced": 0,
+    "_locale": "en_US",
+    "_storefront": "USA",
+    "_storeKitErrors": []
+  },
+  "subscriptionGroups": [
+    {
+      "id": "22366942",
+      "localizations": [
+        {
+          "description": "",
+          "displayName": "Luka Supporter",
+          "locale": "en_US"
+        }
+      ],
+      "name": "Supporter",
+      "subscriptions": [
+        {
+          "adHocOffers": [],
+          "codeOffers": [],
+          "displayPrice": "9.99",
+          "familyShareable": false,
+          "groupNumber": 1,
+          "internalID": "6809559702",
+          "introductoryOffer": null,
+          "localizations": [
+            {
+              "description": "Helps pay for the server that powers Live Activities.",
+              "displayName": "The Whole Fridge",
+              "locale": "en_US"
+            }
+          ],
+          "productID": "com.kylebashour.Glimpse.supporter.mega.monthly",
+          "recurringSubscriptionPeriod": "P1M",
+          "referenceName": "Mega Supporter Monthly",
+          "subscriptionGroupID": "22366942",
+          "type": "RecurringSubscription",
+          "winbackOffers": []
+        },
+        {
+          "adHocOffers": [],
+          "codeOffers": [],
+          "displayPrice": "4.99",
+          "familyShareable": false,
+          "groupNumber": 2,
+          "internalID": "6809559490",
+          "introductoryOffer": null,
+          "localizations": [
+            {
+              "description": "Helps pay for the server that powers Live Activities.",
+              "displayName": "Juice Box",
+              "locale": "en_US"
+            }
+          ],
+          "productID": "com.kylebashour.Glimpse.supporter.super.monthly",
+          "recurringSubscriptionPeriod": "P1M",
+          "referenceName": "Super Supporter Monthly",
+          "subscriptionGroupID": "22366942",
+          "type": "RecurringSubscription",
+          "winbackOffers": []
+        },
+        {
+          "adHocOffers": [],
+          "codeOffers": [],
+          "displayPrice": "1.99",
+          "familyShareable": false,
+          "groupNumber": 3,
+          "internalID": "6809558033",
+          "introductoryOffer": null,
+          "localizations": [
+            {
+              "description": "Helps pay for the server that powers Live Activities.",
+              "displayName": "Glucose Tab",
+              "locale": "en_US"
+            }
+          ],
+          "productID": "com.kylebashour.Glimpse.supporter.monthly",
+          "recurringSubscriptionPeriod": "P1M",
+          "referenceName": "Supporter Monthly",
+          "subscriptionGroupID": "22366942",
+          "type": "RecurringSubscription",
+          "winbackOffers": []
+        }
+      ]
+    }
+  ],
+  "version": {
+    "major": 4,
+    "minor": 0
+  }
+}

--- a/Luka/LukaApp.swift
+++ b/Luka/LukaApp.swift
@@ -19,6 +19,7 @@ struct LukaApp: App {
     @Environment(\.requestReview) private var requestReview
 
     @State private var viewModel = RootViewModel()
+    @State private var supporterStore = SupporterStore()
 
     private let liveActivityManager = LiveActivityManager.shared
 
@@ -38,7 +39,9 @@ struct LukaApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootView().environment(viewModel)
+            RootView()
+                .environment(viewModel)
+                .environment(supporterStore)
                 .task {
                     // Request review after 10 launches
                     if Defaults[.launchCount] >= 10 {
@@ -52,6 +55,9 @@ struct LukaApp: App {
             } else if scenePhase == .active {
                 viewModel.loadCredentials()
                 liveActivityManager.syncState()
+                Task {
+                    await supporterStore.refreshEntitlement()
+                }
             }
         }
     }

--- a/Luka/Store/SupportPrompt.swift
+++ b/Luka/Store/SupportPrompt.swift
@@ -1,0 +1,34 @@
+//
+//  SupportPrompt.swift
+//  Luka
+//
+//  Created by Claude on 9/7/26.
+//
+
+import Foundation
+
+/// Decides when to ask the user to support Luka after starting a Live Activity.
+enum SupportPrompt {
+    /// Starts before the first ask; the first Live Activity should be free of nagging.
+    static let minimumStartCount = 2
+
+    /// How long to wait before asking again after a dismissed prompt.
+    static let repromptInterval: TimeInterval = 30 * 24 * 60 * 60
+
+    static func shouldShow(
+        startCount: Int,
+        isSupporter: Bool,
+        lastPromptDate: Date?,
+        now: Date = .now
+    ) -> Bool {
+        guard !isSupporter, startCount >= minimumStartCount else {
+            return false
+        }
+
+        guard let lastPromptDate else {
+            return true
+        }
+
+        return now.timeIntervalSince(lastPromptDate) >= repromptInterval
+    }
+}

--- a/Luka/Store/SupporterStore.swift
+++ b/Luka/Store/SupporterStore.swift
@@ -1,0 +1,193 @@
+//
+//  SupporterStore.swift
+//  Luka
+//
+//  Created by Claude on 9/7/26.
+//
+
+import Foundation
+import StoreKit
+import TelemetryDeck
+
+/// The optional monthly "supporter" subscriptions. All tiers live in one App
+/// Store subscription group, so switching between them is an upgrade or
+/// downgrade rather than a second subscription. Ordered lowest to highest.
+enum SupporterTier: String, CaseIterable, Identifiable {
+    case supporter = "com.kylebashour.Glimpse.supporter.monthly"
+    case superSupporter = "com.kylebashour.Glimpse.supporter.super.monthly"
+    case megaSupporter = "com.kylebashour.Glimpse.supporter.mega.monthly"
+
+    var id: String { rawValue }
+
+    var name: LocalizedStringResource {
+        switch self {
+        case .supporter: "Glucose Tab"
+        case .superSupporter: "Juice Box"
+        case .megaSupporter: "The Whole Fridge"
+        }
+    }
+
+    /// Opening line of the thank-you copy, phrased to read naturally with the name.
+    var thanks: LocalizedStringResource {
+        switch self {
+        case .supporter: "Thanks for the glucose tab!"
+        case .superSupporter: "Thanks for the juice box!"
+        case .megaSupporter: "Thanks for the whole fridge!"
+        }
+    }
+
+    var description: LocalizedStringResource {
+        switch self {
+        case .supporter: "Chips in on the bill."
+        case .superSupporter: "Goes a long way."
+        case .megaSupporter: "Above and beyond."
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .supporter: "pill.fill"
+        case .superSupporter: "waterbottle.fill"
+        case .megaSupporter: "refrigerator.fill"
+        }
+    }
+
+    /// Shown before the App Store products load.
+    var fallbackDisplayPrice: String {
+        switch self {
+        case .supporter: "$1.99"
+        case .superSupporter: "$4.99"
+        case .megaSupporter: "$9.99"
+        }
+    }
+}
+
+/// Manages the supporter subscriptions, which help pay for the server that
+/// powers Live Activities. They unlock nothing; it's a tip jar.
+@Observable @MainActor
+final class SupporterStore {
+    static let termsOfUseURL = URL(string: "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/")!
+    static let privacyPolicyURL = URL(string: "https://pitou.tech/luka-privacy")!
+
+    private(set) var products: [SupporterTier: Product] = [:]
+    private(set) var currentTier: SupporterTier?
+    private(set) var isPurchasing = false
+    var purchaseError: String?
+
+    var isSupporter: Bool {
+        currentTier != nil
+    }
+
+    /// The cheapest tier's price, for "from $1.99/month" copy.
+    var lowestDisplayPrice: String {
+        displayPrice(for: .supporter)
+    }
+
+    func displayPrice(for tier: SupporterTier) -> String {
+        products[tier]?.displayPrice ?? tier.fallbackDisplayPrice
+    }
+
+    @ObservationIgnored private var updatesTask: Task<Void, Never>?
+
+    init() {
+        // Transactions can arrive outside a purchase flow (renewals, Ask to Buy
+        // approvals, purchases on another device). Finish them and refresh.
+        updatesTask = Task { [weak self] in
+            for await result in Transaction.updates {
+                if case .verified(let transaction) = result {
+                    await transaction.finish()
+                }
+                await self?.refreshEntitlement()
+            }
+        }
+
+        Task {
+            await load()
+        }
+    }
+
+    func load() async {
+        await refreshEntitlement()
+
+        do {
+            let loaded = try await Product.products(for: SupporterTier.allCases.map(\.rawValue))
+            var products: [SupporterTier: Product] = [:]
+            for product in loaded {
+                if let tier = SupporterTier(rawValue: product.id) {
+                    products[tier] = product
+                }
+            }
+            self.products = products
+        } catch {
+            print("Failed to load supporter products: \(error)")
+        }
+    }
+
+    func refreshEntitlement() async {
+        var active: SupporterTier?
+
+        for await result in Transaction.currentEntitlements {
+            guard case .verified(let transaction) = result,
+                  transaction.revocationDate == nil,
+                  let tier = SupporterTier(rawValue: transaction.productID)
+            else {
+                continue
+            }
+
+            // Only one subscription in a group is active at a time, but be
+            // defensive and keep the highest tier if several show up.
+            if active == nil || tier > active! {
+                active = tier
+            }
+        }
+
+        currentTier = active
+    }
+
+    func purchase(_ tier: SupporterTier, source: String) async {
+        guard let product = products[tier], !isPurchasing else { return }
+
+        isPurchasing = true
+        defer { isPurchasing = false }
+
+        let parameters = ["source": source, "tier": tier.rawValue]
+
+        do {
+            switch try await product.purchase() {
+            case .success(let verification):
+                if case .verified(let transaction) = verification {
+                    await transaction.finish()
+                }
+                await refreshEntitlement()
+                TelemetryDeck.signal("Support.purchased", parameters: parameters)
+            case .pending:
+                TelemetryDeck.signal("Support.pending", parameters: parameters)
+            case .userCancelled:
+                TelemetryDeck.signal("Support.cancelled", parameters: parameters)
+            @unknown default:
+                break
+            }
+        } catch {
+            purchaseError = error.localizedDescription
+            TelemetryDeck.signal("Support.failed", parameters: parameters)
+        }
+    }
+
+    func restore() async {
+        do {
+            try await AppStore.sync()
+        } catch {
+            purchaseError = error.localizedDescription
+        }
+
+        await refreshEntitlement()
+        TelemetryDeck.signal("Support.restored", parameters: ["isSupporter": isSupporter.description])
+    }
+}
+
+extension SupporterTier: Comparable {
+    static func < (lhs: SupporterTier, rhs: SupporterTier) -> Bool {
+        let all = SupporterTier.allCases
+        return all.firstIndex(of: lhs)! < all.firstIndex(of: rhs)!
+    }
+}

--- a/Luka/Views/MainView.swift
+++ b/Luka/Views/MainView.swift
@@ -13,6 +13,7 @@ import WidgetKit
 
 @MainActor struct MainView: View {
     @Environment(RootViewModel.self) private var viewModel
+    @Environment(SupporterStore.self) private var supporterStore
     @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     @Default(.selectedRange) private var portraitRange
@@ -23,10 +24,14 @@ import WidgetKit
     @Default(.graphUpperBound) private var upperGraphRange
     @Default(.unit) private var unit
     @Default(.dismissedBannerIDs) private var dismissedBannerIDs
+    @Default(.supportBannerDismissed) private var supportBannerDismissed
+    @Default(.liveActivityStartCount) private var liveActivityStartCount
+    @Default(.lastSupportPromptDate) private var lastSupportPromptDate
 
     @Default(.isLiveActivityRunning) private var isActivityActive
 
     @State private var isPresentingSettings = false
+    @State private var supportSheetSource: SupportSource?
     @State private var liveViewModel = LiveViewModel()
     @State private var isActivityLoading = false
     @State private var selectedChartReading: LiveActivityState.Reading?
@@ -140,6 +145,18 @@ import WidgetKit
 
                 if !isCompact {
                     liveActivityButton()
+
+                    if showsSupportBanner {
+                        SupportBannerView(displayPrice: supporterStore.lowestDisplayPrice) {
+                            supportSheetSource = .banner
+                        } onDismiss: {
+                            supportBannerDismissed = true
+                            TelemetryDeck.signal("Support.bannerDismissed")
+                        }
+                        .withReadableWidth()
+                        .frame(maxWidth: .infinity)
+                        .padding([.horizontal, .bottom])
+                    }
                 }
             }
             .padding(.top, isCompact ? nil : 0)
@@ -171,6 +188,9 @@ import WidgetKit
                 SettingsView()
             }
         }
+        .sheet(item: $supportSheetSource) { source in
+            SupportView(source: source)
+        }
         .onAppear {
             liveViewModel.setUpClientAndBeginRefreshing()
             haptics.prepare()
@@ -181,6 +201,27 @@ import WidgetKit
             haptics.prepare()
         }
         .animation(.snappy, value: dismissedBannerIDs)
+        .animation(.snappy, value: showsSupportBanner)
+    }
+
+    private var showsSupportBanner: Bool {
+        !supporterStore.isSupporter && !supportBannerDismissed
+    }
+
+    /// After the second (and later) start, ask for support. Re-asks at most once
+    /// a month, and never once the user subscribes.
+    private func showSupportPromptIfNeeded() {
+        guard SupportPrompt.shouldShow(
+            startCount: liveActivityStartCount,
+            isSupporter: supporterStore.isSupporter,
+            lastPromptDate: lastSupportPromptDate
+        ) else {
+            return
+        }
+
+        lastSupportPromptDate = .now
+        supportSheetSource = .prompt
+        TelemetryDeck.signal("Support.promptShown", parameters: ["startCount": String(liveActivityStartCount)])
     }
 
     private func liveActivityButton() -> some View {
@@ -229,6 +270,7 @@ import WidgetKit
         defer { isActivityLoading = false }
 
         do {
+            let didStart = !isActivityActive
             if isActivityActive {
                 _ = try await EndLiveActivityIntent().perform()
             } else {
@@ -236,6 +278,10 @@ import WidgetKit
             }
             LiveActivityManager.shared.syncState()
             UINotificationFeedbackGenerator().notificationOccurred(.success)
+
+            if didStart {
+                showSupportPromptIfNeeded()
+            }
         } catch {
             print("Failed to toggle Live Activity: \(error)")
             UINotificationFeedbackGenerator().notificationOccurred(.error)
@@ -283,6 +329,8 @@ import WidgetKit
 
 #Preview {
     NavigationStack {
-        MainView().environment(RootViewModel())
+        MainView()
+            .environment(RootViewModel())
+            .environment(SupporterStore())
     }
 }

--- a/Luka/Views/SettingsView.swift
+++ b/Luka/Views/SettingsView.swift
@@ -12,7 +12,10 @@ import KeychainAccess
 
 struct SettingsView: View {
     @Environment(RootViewModel.self) private var viewModel
+    @Environment(SupporterStore.self) private var supporterStore
     @Environment(\.dismiss) private var dismiss
+
+    @State private var isPresentingSupport = false
 
     @Default(.targetRangeLowerBound) private var lowerTargetRange
     @Default(.targetRangeUpperBound) private var upperTargetRange
@@ -111,6 +114,39 @@ struct SettingsView: View {
             }
 
             Section {
+                if supporterStore.isSupporter {
+                    Button {
+                        isPresentingSupport = true
+                    } label: {
+                        SettingsRow("Manage support", systemImage: "heart.fill")
+                    }
+                } else {
+                    Button {
+                        isPresentingSupport = true
+                    } label: {
+                        SettingsRow("Support Luka", systemImage: "heart")
+                    }
+
+                    Button {
+                        Task {
+                            await supporterStore.restore()
+                        }
+                    } label: {
+                        SettingsRow("Restore purchases", systemImage: "arrow.clockwise")
+                    }
+                }
+            } header: {
+                Text("Support")
+            } footer: {
+                if let currentTier = supporterStore.currentTier {
+                    Text("\(Text(currentTier.thanks)) It keeps Live Activities running.")
+                } else {
+                    Text("Live Activities run on a server that costs money. Chip in from \(supporterStore.lowestDisplayPrice)/mo.")
+                }
+            }
+            .fontWeight(.medium)
+
+            Section {
                 ShareLink(item: URL(string: "https://apps.apple.com/us/app/luka-blood-glucose-readings/id6499279663")!) {
                     SettingsRow("Share Luka", systemImage: "square.and.arrow.up")
                 }
@@ -160,8 +196,12 @@ struct SettingsView: View {
             .fontWeight(.medium)
         }
         .animation(.default, value: showChartLiveActivity)
+        .animation(.default, value: supporterStore.isSupporter)
         .listStyle(.insetGrouped)
         .navigationTitle("Settings")
+        .sheet(isPresented: $isPresentingSupport) {
+            SupportView(source: .settings)
+        }
         .toolbar {
             if #available(iOS 26, *) {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -210,6 +250,8 @@ private struct GraphSliderView: View {
 
 #Preview {
     NavigationStack {
-        SettingsView().environment(RootViewModel())
+        SettingsView()
+            .environment(RootViewModel())
+            .environment(SupporterStore())
     }
 }

--- a/Luka/Views/SupportBannerView.swift
+++ b/Luka/Views/SupportBannerView.swift
@@ -1,0 +1,63 @@
+//
+//  SupportBannerView.swift
+//  Luka
+//
+//  Created by Claude on 9/7/26.
+//
+
+import SwiftUI
+
+/// Promo shown under the Live Activity button asking non-supporters to help
+/// pay for the server. Tapping opens `SupportView`; the X hides it for good.
+struct SupportBannerView: View {
+    var displayPrice: String
+    var onTap: () -> Void
+    var onDismiss: () -> Void
+
+    var body: some View {
+        Button {
+            onTap()
+        } label: {
+            HStack(alignment: .top, spacing: .spacing6) {
+                Image(systemName: "heart.fill")
+                    .foregroundStyle(.accent)
+                    .font(.headline)
+                    .padding(.top, .spacing1)
+
+                VStack(alignment: .leading, spacing: .spacing1) {
+                    Text("Support Luka")
+                        .font(.headline)
+
+                    Text("Live Activities run on a server that costs money. Chip in from \(displayPrice)/mo.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .multilineTextAlignment(.leading)
+
+                Spacer(minLength: 0)
+
+                Button {
+                    onDismiss()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                        .font(.headline)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(
+                Color(.systemGroupedBackground),
+                in: .rect(cornerRadius: .defaultCornerRadius)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    SupportBannerView(displayPrice: "$1.99", onTap: {}, onDismiss: {})
+        .padding()
+}

--- a/Luka/Views/SupportView.swift
+++ b/Luka/Views/SupportView.swift
@@ -1,0 +1,267 @@
+//
+//  SupportView.swift
+//  Luka
+//
+//  Created by Claude on 9/7/26.
+//
+
+import StoreKit
+import SwiftUI
+import TelemetryDeck
+
+/// Where `SupportView` was opened from, for telemetry.
+enum SupportSource: String, Identifiable {
+    case banner = "Banner"
+    case prompt = "Prompt"
+    case settings = "Settings"
+
+    var id: String { rawValue }
+}
+
+/// Explains why Luka asks for support and offers the monthly supporter tiers.
+/// Presented from the promo banner, Settings, and the post-start prompt.
+struct SupportView: View {
+    @Environment(SupporterStore.self) private var store
+    @Environment(\.dismiss) private var dismiss
+
+    var source: SupportSource
+
+    @State private var selectedTier: SupporterTier = .supporter
+    @State private var isPresentingManageSubscriptions = false
+
+    private var isCurrentTierSelected: Bool {
+        store.currentTier == selectedTier
+    }
+
+    var body: some View {
+        NavigationStack {
+            FooterScrollView {
+                VStack(alignment: .leading, spacing: .largeVerticalSpacing) {
+                    Image(systemName: "heart.fill")
+                        .font(.system(size: 56))
+                        .foregroundStyle(.accent)
+
+                    VStack(alignment: .leading, spacing: .spacing4) {
+                        Text(store.isSupporter ? "Thank You!" : "Support Luka")
+                            .font(.title.bold())
+
+                        if let currentTier = store.currentTier {
+                            Text("\(Text(currentTier.thanks)) It keeps Live Activities running.")
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("Live Activities run on a server I pay for every month. Luka is free with no ads. Supporting unlocks nothing, but it keeps the lights on.")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .multilineTextAlignment(.leading)
+
+                    VStack(spacing: .spacing4) {
+                        ForEach(SupporterTier.allCases) { tier in
+                            TierRow(
+                                tier: tier,
+                                displayPrice: store.displayPrice(for: tier),
+                                isSelected: tier == selectedTier,
+                                isCurrent: tier == store.currentTier
+                            ) {
+                                selectedTier = tier
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .withReadableWidth()
+                .padding()
+                .padding(.horizontal)
+                .padding(.top, .spacing8)
+            } footer: {
+                footer
+                    .withReadableWidth()
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .padding(.horizontal)
+            }
+            .toolbar {
+                if #available(iOS 26, *) {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button(role: .close) {
+                            dismiss()
+                        }
+                    }
+                } else {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") {
+                            dismiss()
+                        }
+                    }
+                }
+            }
+        }
+        .fontDesign(.rounded)
+        .animation(.default, value: store.currentTier)
+        .animation(.snappy, value: selectedTier)
+        .onAppear {
+            selectedTier = store.currentTier ?? .supporter
+            TelemetryDeck.signal("Support.viewed", parameters: ["source": source.rawValue])
+        }
+        .onChange(of: store.currentTier) {
+            if let currentTier = store.currentTier {
+                selectedTier = currentTier
+            }
+        }
+        .alert(
+            "Something Went Wrong",
+            isPresented: Binding(
+                get: { store.purchaseError != nil },
+                set: { if !$0 { store.purchaseError = nil } }
+            ),
+            actions: {
+                Button("OK") {}
+            },
+            message: {
+                Text(store.purchaseError ?? "")
+            }
+        )
+        .manageSubscriptionsSheet(isPresented: $isPresentingManageSubscriptions)
+    }
+
+    @ViewBuilder private var footer: some View {
+        VStack(spacing: .spacing6) {
+            if store.isSupporter, isCurrentTierSelected {
+                prominentButton("Manage Subscription") {
+                    isPresentingManageSubscriptions = true
+                }
+            } else {
+                prominentButton(
+                    store.isSupporter
+                        ? "Switch to \(Text(selectedTier.name))"
+                        : "Support for \(store.displayPrice(for: selectedTier))/mo"
+                ) {
+                    Task {
+                        await store.purchase(selectedTier, source: source.rawValue)
+                    }
+                }
+                .disabled(store.products[selectedTier] == nil || store.isPurchasing)
+            }
+
+            if !store.isSupporter {
+                Button("Restore Purchases") {
+                    Task {
+                        await store.restore()
+                    }
+                }
+                .font(.subheadline.weight(.medium))
+                .disabled(store.isPurchasing)
+
+                legalText
+            }
+        }
+    }
+
+    private func prominentButton(_ title: LocalizedStringKey, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .animation(nil, value: store.isPurchasing)
+                .opacity(store.isPurchasing ? 0 : 1)
+                .overlay {
+                    if store.isPurchasing {
+                        ProgressView().tint(.white)
+                    }
+                }
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+                .padding()
+        }
+        .modifier {
+            if #available(iOS 26, *) {
+                $0.buttonStyle(.glassProminent)
+            } else {
+                $0.buttonStyle(.borderedProminent)
+            }
+        }
+        .buttonBorderShape(.capsule)
+    }
+
+    private var legalText: some View {
+        VStack(spacing: .spacing1) {
+            Text("Renews monthly. Cancel anytime in Settings.")
+
+            HStack(spacing: .spacing1) {
+                Link("Terms of Use", destination: SupporterStore.termsOfUseURL)
+                Text("•")
+                Link("Privacy Policy", destination: SupporterStore.privacyPolicyURL)
+            }
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.top, .spacing4)
+    }
+}
+
+private struct TierRow: View {
+    var tier: SupporterTier
+    var displayPrice: String
+    var isSelected: Bool
+    var isCurrent: Bool
+    var onSelect: () -> Void
+
+    var body: some View {
+        Button {
+            onSelect()
+        } label: {
+            HStack(spacing: .spacing6) {
+                Image(systemName: tier.systemImage)
+                    .font(.title3)
+                    .foregroundStyle(.accent)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: .spacing1) {
+                    HStack(spacing: .spacing4) {
+                        Text(tier.name)
+                            .font(.headline)
+                            .fixedSize(horizontal: true, vertical: false)
+
+                        if isCurrent {
+                            Text("Current")
+                                .font(.caption2.weight(.semibold))
+                                .padding(.horizontal, .spacing4)
+                                .padding(.vertical, .spacing1)
+                                .background(.accent.opacity(0.15), in: .capsule)
+                                .foregroundStyle(.accent)
+                        }
+                    }
+
+                    Text(tier.description)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .multilineTextAlignment(.leading)
+                .layoutPriority(1)
+
+                Spacer(minLength: .spacing4)
+
+                Text("\(displayPrice)/mo")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(
+                Color(.systemGroupedBackground),
+                in: .rect(cornerRadius: .defaultCornerRadius)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: .defaultCornerRadius)
+                    .strokeBorder(.tint, lineWidth: isSelected ? 2 : 0)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+#Preview {
+    SupportView(source: .settings)
+        .environment(SupporterStore())
+}

--- a/LukaTests/LukaTests.swift
+++ b/LukaTests/LukaTests.swift
@@ -19,3 +19,30 @@ struct DateTests {
     }
 
 }
+
+struct SupportPromptTests {
+
+    @Test func test_doesNotShowBeforeSecondStart() {
+        #expect(!SupportPrompt.shouldShow(startCount: 0, isSupporter: false, lastPromptDate: nil))
+        #expect(!SupportPrompt.shouldShow(startCount: 1, isSupporter: false, lastPromptDate: nil))
+    }
+
+    @Test func test_showsOnSecondStart() {
+        #expect(SupportPrompt.shouldShow(startCount: 2, isSupporter: false, lastPromptDate: nil))
+        #expect(SupportPrompt.shouldShow(startCount: 50, isSupporter: false, lastPromptDate: nil))
+    }
+
+    @Test func test_neverShowsForSupporters() {
+        #expect(!SupportPrompt.shouldShow(startCount: 10, isSupporter: true, lastPromptDate: nil))
+    }
+
+    @Test func test_repromptsAfterInterval() {
+        let now = Date.now
+        let recent = now.addingTimeInterval(-SupportPrompt.repromptInterval + 60)
+        let old = now.addingTimeInterval(-SupportPrompt.repromptInterval - 60)
+
+        #expect(!SupportPrompt.shouldShow(startCount: 5, isSupporter: false, lastPromptDate: recent, now: now))
+        #expect(SupportPrompt.shouldShow(startCount: 5, isSupporter: false, lastPromptDate: old, now: now))
+    }
+
+}

--- a/Shared/Intents/StartLiveActivityIntent.swift
+++ b/Shared/Intents/StartLiveActivityIntent.swift
@@ -89,6 +89,8 @@ struct StartLiveActivityIntent: LiveActivityIntent {
             pushType: .token
         )
 
+        Defaults[.liveActivityStartCount] += 1
+
         TelemetryDeck.signal(
             "LiveActivity.started",
             parameters: ["source": source]

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -1,9 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    ":00" : {
-      "shouldTranslate" : false
-    },
     "%@ %@" : {
       "localizations" : {
         "de" : {
@@ -46,6 +43,56 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ %2$@"
+          }
+        }
+      }
+    },
+    "%@ It keeps Live Activities running." : {
+
+    },
+    "%@ ago" : {
+      "comment" : "Relative time suffix, e.g. '5 min ago'",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vor %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ago"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hace %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "il y a %@"
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "il y a %@"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ siden"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ sedan"
           }
         }
       }
@@ -107,53 +154,6 @@
         }
       }
     },
-    "%@ ago" : {
-      "comment" : "Relative time suffix, e.g. '5 min ago'",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vor %@"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ago"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "hace %@"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "il y a %@"
-          }
-        },
-        "fr-CA" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "il y a %@"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ siden"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ sedan"
-          }
-        }
-      }
-    },
     "%@%@" : {
       "localizations" : {
         "de" : {
@@ -200,6 +200,9 @@
         }
       }
     },
+    "%@/mo" : {
+
+    },
     "24 hours" : {
       "localizations" : {
         "de" : {
@@ -245,6 +248,12 @@
           }
         }
       }
+    },
+    ":00" : {
+      "shouldTranslate" : false
+    },
+    "Above and beyond." : {
+
     },
     "Activities enabled" : {
       "localizations" : {
@@ -532,6 +541,9 @@
         }
       }
     },
+    "Chips in on the bill." : {
+
+    },
     "Configure graph widget settings." : {
       "localizations" : {
         "de" : {
@@ -664,45 +676,8 @@
         }
       }
     },
-    "Current date" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktuelles Datum"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fecha actual"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date actuelle"
-          }
-        },
-        "fr-CA" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date actuelle"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gjeldende dato"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktuellt datum"
-          }
-        }
-      }
+    "Current" : {
+
     },
     "Current Reading" : {
       "localizations" : {
@@ -746,6 +721,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aktuellt värde"
+          }
+        }
+      }
+    },
+    "Current date" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuelles Datum"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha actual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date actuelle"
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date actuelle"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gjeldende dato"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuellt datum"
           }
         }
       }
@@ -1014,6 +1029,9 @@
         }
       }
     },
+    "Dismiss" : {
+
+    },
     "Done" : {
       "localizations" : {
         "de" : {
@@ -1244,46 +1262,6 @@
         }
       }
     },
-    "End all Live Activities" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Live-Aktivitäten beenden"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizar todas las Actividades en Vivo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrêter toutes les activités en direct"
-          }
-        },
-        "fr-CA" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrêter toutes les activités en direct"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avslutt alle Live Activities"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avsluta alla Live Activities"
-          }
-        }
-      }
-    },
     "End Live Activity" : {
       "localizations" : {
         "de" : {
@@ -1406,6 +1384,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avsluta Live Activity på servern"
+          }
+        }
+      }
+    },
+    "End all Live Activities" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Live-Aktivitäten beenden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizar todas las Actividades en Vivo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrêter toutes les activités en direct"
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrêter toutes les activités en direct"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avslutt alle Live Activities"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avsluta alla Live Activities"
           }
         }
       }
@@ -1708,51 +1726,11 @@
         }
       }
     },
-    "Graph range" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeitraum"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Graph range"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rango del gráfico"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plage du graphique"
-          }
-        },
-        "fr-CA" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plage du graphique"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grafperiode"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tidsperiod"
-          }
-        }
-      }
+    "Glucose Tab" : {
+
+    },
+    "Goes a long way." : {
+
     },
     "Graph Range" : {
       "localizations" : {
@@ -1846,52 +1824,6 @@
         }
       }
     },
-    "Graph upper bound" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oberer Grenzwert"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Graph upper bound"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Límite superior del gráfico"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite supérieure du graphique"
-          }
-        },
-        "fr-CA" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite supérieure du graphique"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grafens øvre grense"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grafens övre gräns"
-          }
-        }
-      }
-    },
     "Graph Widget" : {
       "localizations" : {
         "de" : {
@@ -1934,6 +1866,98 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Grafwidget"
+          }
+        }
+      }
+    },
+    "Graph range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitraum"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Graph range"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rango del gráfico"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plage du graphique"
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plage du graphique"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grafperiode"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidsperiod"
+          }
+        }
+      }
+    },
+    "Graph upper bound" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oberer Grenzwert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Graph upper bound"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Límite superior del gráfico"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limite supérieure du graphique"
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limite supérieure du graphique"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grafens øvre grense"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grafens övre gräns"
           }
         }
       }
@@ -2027,9 +2051,6 @@
         }
       }
     },
-    "isLiveActivityRunning" : {
-      "shouldTranslate" : false
-    },
     "Japan" : {
       "localizations" : {
         "de" : {
@@ -2075,6 +2096,9 @@
           }
         }
       }
+    },
+    "Juice Box" : {
+
     },
     "Just now" : {
       "localizations" : {
@@ -2215,46 +2239,6 @@
         }
       }
     },
-    "Launch on tap" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beim Tippen öffnen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir al tocar"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir en touchant"
-          }
-        },
-        "fr-CA" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir en touchant"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åpne ved trykk"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öppna vid tryck"
-          }
-        }
-      }
-    },
     "Launch on Tap" : {
       "localizations" : {
         "de" : {
@@ -2285,6 +2269,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ouvrir au toucher"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Åpne ved trykk"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Öppna vid tryck"
+          }
+        }
+      }
+    },
+    "Launch on tap" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beim Tippen öffnen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir al tocar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir en touchant"
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir en touchant"
           }
         },
         "nb" : {
@@ -2565,6 +2589,12 @@
         }
       }
     },
+    "Live Activities run on a server I pay for every month. Luka is free with no ads. Supporting unlocks nothing, but it keeps the lights on." : {
+
+    },
+    "Live Activities run on a server that costs money. Chip in from %@/mo." : {
+
+    },
     "Live Activity" : {
       "localizations" : {
         "de" : {
@@ -2611,46 +2641,6 @@
         }
       }
     },
-    "Live Activity alerts" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Live-Aktivität-Warnungen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alertas de Actividad en Vivo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alertes d’activité en direct"
-          }
-        },
-        "fr-CA" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alertes d’activité en direct"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Live Activity-varsler"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Live Activity-varningar"
-          }
-        }
-      }
-    },
     "Live Activity Debug" : {
       "localizations" : {
         "de" : {
@@ -2687,6 +2677,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Live Activity-felsökning"
+          }
+        }
+      }
+    },
+    "Live Activity alerts" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live-Aktivität-Warnungen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alertas de Actividad en Vivo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alertes d’activité en direct"
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alertes d’activité en direct"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Activity-varsler"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Activity-varningar"
           }
         }
       }
@@ -3048,11 +3078,11 @@
         }
       }
     },
-    "m" : {
-      "shouldTranslate" : false
+    "Manage Subscription" : {
+
     },
-    "m ago" : {
-      "shouldTranslate" : false
+    "Manage support" : {
+
     },
     "Max" : {
       "localizations" : {
@@ -3410,6 +3440,52 @@
         }
       }
     },
+    "OK" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
+    },
     "Off" : {
       "localizations" : {
         "de" : {
@@ -3499,52 +3575,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Offline"
-          }
-        }
-      }
-    },
-    "OK" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "fr-CA" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
           }
         }
       }
@@ -3690,6 +3720,9 @@
         }
       }
     },
+    "Privacy Policy" : {
+
+    },
     "Push date" : {
       "localizations" : {
         "de" : {
@@ -3772,6 +3805,9 @@
     },
     "Push-to-start" : {
       "shouldTranslate" : false
+    },
+    "Reading & Delta" : {
+
     },
     "Reading Graph" : {
       "localizations" : {
@@ -4037,6 +4073,9 @@
         }
       }
     },
+    "Renews monthly. Cancel anytime in Settings." : {
+
+    },
     "Restart" : {
       "localizations" : {
         "de" : {
@@ -4122,6 +4161,12 @@
           }
         }
       }
+    },
+    "Restore Purchases" : {
+
+    },
+    "Restore purchases" : {
+
     },
     "Running" : {
       "localizations" : {
@@ -5137,6 +5182,18 @@
     "Sugarmate" : {
       "shouldTranslate" : false
     },
+    "Support" : {
+
+    },
+    "Support Luka" : {
+
+    },
+    "Support for %@/mo" : {
+
+    },
+    "Switch to %@" : {
+
+    },
     "Tap Action" : {
       "localizations" : {
         "de" : {
@@ -5182,6 +5239,24 @@
           }
         }
       }
+    },
+    "Terms of Use" : {
+
+    },
+    "Thank You!" : {
+
+    },
+    "Thanks for the glucose tab!" : {
+
+    },
+    "Thanks for the juice box!" : {
+
+    },
+    "Thanks for the whole fridge!" : {
+
+    },
+    "The Whole Fridge" : {
+
     },
     "This version of Luka is no longer supported. Please update to continue." : {
       "localizations" : {
@@ -6026,6 +6101,18 @@
           }
         }
       }
+    },
+    "isLiveActivityRunning" : {
+      "shouldTranslate" : false
+    },
+    "m" : {
+      "shouldTranslate" : false
+    },
+    "m ago" : {
+      "shouldTranslate" : false
+    },
+    "•" : {
+
     }
   },
   "version" : "1.1"

--- a/Shared/Utilities/Defaults.swift
+++ b/Shared/Utilities/Defaults.swift
@@ -47,6 +47,13 @@ extension Defaults.Keys {
     static let pushToStartToken = Key<String?>("pushToStartToken", default: nil, suite: .shared)
     // Device-local: following a sensor over Bluetooth is inherently per-device.
     static let directToG7Enabled = Key<Bool>("directToG7Enabled", default: false, suite: .shared)
+
+    // Supporter subscription prompts. The start count is bumped by the intent, which can
+    // run in the widget extension (Control Center, Shortcuts), so it lives in the shared
+    // suite. Dismissals sync so the user isn't asked again on every device.
+    static let liveActivityStartCount = Key<Int>("liveActivityStartCount", default: 0, suite: .shared)
+    static let supportBannerDismissed = Key<Bool>("supportBannerDismissed", default: false, suite: .shared, iCloud: true)
+    static let lastSupportPromptDate = Key<Date?>("lastSupportPromptDate", default: nil, suite: .shared, iCloud: true)
 }
 
 extension AccountLocation: Defaults.Serializable {}

--- a/Shared/Utilities/Defaults.swift
+++ b/Shared/Utilities/Defaults.swift
@@ -51,7 +51,7 @@ extension Defaults.Keys {
     // Supporter subscription prompts. The start count is bumped by the intent, which can
     // run in the widget extension (Control Center, Shortcuts), so it lives in the shared
     // suite. Dismissals sync so the user isn't asked again on every device.
-    static let liveActivityStartCount = Key<Int>("liveActivityStartCount", default: 0, suite: .shared)
+    static let liveActivityStartCount = Key<Int>("liveActivityStartCount", default: 0, suite: .shared, iCloud: true)
     static let supportBannerDismissed = Key<Bool>("supportBannerDismissed", default: false, suite: .shared, iCloud: true)
     static let lastSupportPromptDate = Key<Date?>("lastSupportPromptDate", default: nil, suite: .shared, iCloud: true)
 }


### PR DESCRIPTION
## Summary

Optional monthly subscriptions that help pay for the server behind Live Activities. They unlock nothing; it's a tip jar.

| Tier | Product ID | Price |
|---|---|---|
| Glucose Tab | `com.kylebashour.Glimpse.supporter.monthly` | $1.99/mo |
| Juice Box | `com.kylebashour.Glimpse.supporter.super.monthly` | $4.99/mo |
| The Whole Fridge | `com.kylebashour.Glimpse.supporter.mega.monthly` | $9.99/mo |

All three are in one App Store Connect subscription group (22366942), so switching tiers is an upgrade/downgrade. They're READY_TO_SUBMIT in ASC with review screenshots uploaded, and go live once attached to an App Store version submission with this build.

- **SupporterStore**: StoreKit 2 products, current tier from entitlements, purchase, restore, background transaction updates, refresh on foreground
- **Support sheet**: tier picker, purchase, restore, manage subscription, Terms of Use and Privacy Policy links; supporter state shows a Current badge and lets you switch tiers
- **Banner** under the Live Activity button, hidden for supporters or once dismissed
- **Settings** gets a Support section
- **Prompt** after the second in-app Live Activity start, at most every 30 days, never for supporters (`SupportPrompt`, unit tested)
- `Luka.storekit` is attached to the Luka scheme for local testing and excluded from the bundle
- Xcode extracted the new strings into the catalog; other locales still need translations

## Test plan

- [x] Unit tests for `SupportPrompt`
- [x] Simulator with StoreKit config: banner shows, sheet loads live prices, purchase of Juice Box completes, thank-you state with Current badge, banner hidden afterwards
- [x] Previews at default and XXX Large Dynamic Type
- [ ] Sandbox purchase on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)