### PR TITLE
Fix dark mode card contrast and support sheet accessibility layout

### DIFF
--- a/Luka/Views/BannerView.swift
+++ b/Luka/Views/BannerView.swift
@@ -40,10 +40,7 @@ struct BannerView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .background(
-            Color(.systemGroupedBackground),
-            in: .rect(cornerRadius: .defaultCornerRadius)
-        )
+        .insetCard()
     }
 }
 

--- a/Luka/Views/SupportBannerView.swift
+++ b/Luka/Views/SupportBannerView.swift
@@ -48,10 +48,7 @@ struct SupportBannerView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
-            .background(
-                Color(.systemGroupedBackground),
-                in: .rect(cornerRadius: .defaultCornerRadius)
-            )
+            .insetCard()
         }
         .buttonStyle(.plain)
     }

--- a/Luka/Views/SupportView.swift
+++ b/Luka/Views/SupportView.swift
@@ -79,6 +79,7 @@ struct SupportView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .padding(.horizontal)
+                    .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
             }
             .toolbar {
                 if #available(iOS 26, *) {
@@ -184,11 +185,19 @@ struct SupportView: View {
     private var legalText: some View {
         VStack(spacing: .spacing1) {
             Text("Renews monthly. Cancel anytime in Settings.")
+                .fixedSize(horizontal: false, vertical: true)
 
-            HStack(spacing: .spacing1) {
-                Link("Terms of Use", destination: SupporterStore.termsOfUseURL)
-                Text("•")
-                Link("Privacy Policy", destination: SupporterStore.privacyPolicyURL)
+            ViewThatFits {
+                HStack(spacing: .spacing1) {
+                    Link("Terms of Use", destination: SupporterStore.termsOfUseURL)
+                    Text("•")
+                    Link("Privacy Policy", destination: SupporterStore.privacyPolicyURL)
+                }
+
+                VStack(spacing: .spacing1) {
+                    Link("Terms of Use", destination: SupporterStore.termsOfUseURL)
+                    Link("Privacy Policy", destination: SupporterStore.privacyPolicyURL)
+                }
             }
         }
         .font(.caption2)
@@ -199,11 +208,17 @@ struct SupportView: View {
 }
 
 private struct TierRow: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     var tier: SupporterTier
     var displayPrice: String
     var isSelected: Bool
     var isCurrent: Bool
     var onSelect: () -> Void
+
+    private var isAccessibilitySize: Bool {
+        dynamicTypeSize.isAccessibilitySize
+    }
 
     var body: some View {
         Button {
@@ -216,10 +231,15 @@ private struct TierRow: View {
                     .frame(width: 28)
 
                 VStack(alignment: .leading, spacing: .spacing1) {
-                    HStack(spacing: .spacing4) {
+                    // Name and badge sit side by side, but stack once the
+                    // text is too large to share a line.
+                    let nameLayout = isAccessibilitySize
+                        ? AnyLayout(VStackLayout(alignment: .leading, spacing: .spacing1))
+                        : AnyLayout(HStackLayout(spacing: .spacing4))
+
+                    nameLayout {
                         Text(tier.name)
                             .font(.headline)
-                            .fixedSize(horizontal: true, vertical: false)
 
                         if isCurrent {
                             Text("Current")
@@ -234,23 +254,21 @@ private struct TierRow: View {
                     Text(tier.description)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
+
+                    if isAccessibilitySize {
+                        price.padding(.top, .spacing1)
+                    }
                 }
                 .multilineTextAlignment(.leading)
-                .layoutPriority(1)
 
-                Spacer(minLength: .spacing4)
-
-                Text("\(displayPrice)/mo")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(isSelected ? Color.accentColor : .secondary)
-                    .fixedSize(horizontal: true, vertical: false)
+                if !isAccessibilitySize {
+                    Spacer(minLength: .spacing4)
+                    price
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
-            .background(
-                Color(.systemGroupedBackground),
-                in: .rect(cornerRadius: .defaultCornerRadius)
-            )
+            .insetCard()
             .overlay {
                 RoundedRectangle(cornerRadius: .defaultCornerRadius)
                     .strokeBorder(.tint, lineWidth: isSelected ? 2 : 0)
@@ -258,6 +276,12 @@ private struct TierRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var price: some View {
+        Text("\(displayPrice)/mo")
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(isSelected ? Color.accentColor : .secondary)
     }
 }
 

--- a/Shared/Style/CardModifier.swift
+++ b/Shared/Style/CardModifier.swift
@@ -33,3 +33,13 @@ struct CardModifier: ViewModifier {
             }
     }
 }
+
+extension View {
+    /// A flat, subtly tinted card for content that sits inside a screen rather
+    /// than floating over it (banners, option rows). Uses the secondary
+    /// background so it stays distinct from the screen in both light and dark
+    /// mode, including elevated contexts like sheets.
+    func insetCard() -> some View {
+        background(.background.secondary, in: .rect(cornerRadius: .defaultCornerRadius))
+    }
+}


### PR DESCRIPTION
## Summary
- Add an `insetCard()` modifier that uses the secondary background so the remote banner, support banner, and tier rows are visibly separated from the screen in dark mode. They used `systemGroupedBackground`, which is pure black in dark mode.
- Remove the `fixedSize` calls on the tier row name and price. At accessibility text sizes they forced the support sheet content (and its footer) wider than the screen, which looked like negative padding.
- At accessibility sizes, stack the tier price and Current badge vertically and let the Terms/Privacy links wrap. The renewal text now takes its full height instead of truncating.
- Cap the support sheet footer's Dynamic Type at XXX Large so it stays compact.

## Test plan
- [x] Rendered BannerView, SupportBannerView, and SupportView in dark mode; cards sample as #1C1C1E on #000000
- [x] Rendered SupportView at Large, AX 2, AX 3, and AX 5; content stays within the screen, no truncation
- [x] Light mode unchanged (card is #F2F2F7 on white)
- [x] Luka scheme builds for iPhone 17 Pro simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)