### PR TITLE
Reprice supporter tiers, refresh tier copy, and cache the supporter state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,8 +231,8 @@ Optional monthly tip-jar subscriptions that help pay for the Live Activity serve
 
 | Tier | Product ID | Price | ASC ID |
 |------|------------|-------|--------|
-| Glucose Tab | `com.kylebashour.Glimpse.supporter.monthly` | $1.99/mo | 6809558033 |
-| Juice Box | `com.kylebashour.Glimpse.supporter.super.monthly` | $4.99/mo | 6809559490 |
+| Glucose Tab | `com.kylebashour.Glimpse.supporter.monthly` | $0.99/mo | 6809558033 |
+| Juice Box | `com.kylebashour.Glimpse.supporter.super.monthly` | $2.99/mo | 6809559490 |
 | The Whole Fridge | `com.kylebashour.Glimpse.supporter.mega.monthly` | $9.99/mo | 6809559702 |
 
 All three live in subscription group 22366942 ("Supporter"), The Whole Fridge at group level 1, so switching tiers is an upgrade/downgrade.

--- a/Luka/Luka.storekit
+++ b/Luka/Luka.storekit
@@ -48,7 +48,7 @@
         {
           "adHocOffers": [],
           "codeOffers": [],
-          "displayPrice": "4.99",
+          "displayPrice": "2.99",
           "familyShareable": false,
           "groupNumber": 2,
           "internalID": "6809559490",
@@ -70,7 +70,7 @@
         {
           "adHocOffers": [],
           "codeOffers": [],
-          "displayPrice": "1.99",
+          "displayPrice": "0.99",
           "familyShareable": false,
           "groupNumber": 3,
           "internalID": "6809558033",

--- a/Luka/Store/SupporterStore.swift
+++ b/Luka/Store/SupporterStore.swift
@@ -5,6 +5,7 @@
 //  Created by Claude on 9/7/26.
 //
 
+import Defaults
 import Foundation
 import StoreKit
 import TelemetryDeck
@@ -38,9 +39,9 @@ enum SupporterTier: String, CaseIterable, Identifiable {
 
     var description: LocalizedStringResource {
         switch self {
-        case .supporter: "Chips in on the bill."
-        case .superSupporter: "Goes a long way."
-        case .megaSupporter: "Above and beyond."
+        case .supporter: "Cheap but fast-acting."
+        case .superSupporter: "A classic."
+        case .megaSupporter: "You're overtreating, but we're here for it."
         }
     }
 
@@ -55,8 +56,8 @@ enum SupporterTier: String, CaseIterable, Identifiable {
     /// Shown before the App Store products load.
     var fallbackDisplayPrice: String {
         switch self {
-        case .supporter: "$1.99"
-        case .superSupporter: "$4.99"
+        case .supporter: "99¢"
+        case .superSupporter: "$2.99"
         case .megaSupporter: "$9.99"
         }
     }
@@ -78,18 +79,33 @@ final class SupporterStore {
         currentTier != nil
     }
 
-    /// The cheapest tier's price, for "from $1.99/month" copy.
+    /// The cheapest tier's price, for "from 99¢/month" copy.
     var lowestDisplayPrice: String {
         displayPrice(for: .supporter)
     }
 
     func displayPrice(for tier: SupporterTier) -> String {
-        products[tier]?.displayPrice ?? tier.fallbackDisplayPrice
+        guard let product = products[tier] else {
+            return tier.fallbackDisplayPrice
+        }
+
+        // Sub-dollar US prices read better as cents ("99¢" rather than "$0.99").
+        // Other storefronts keep Apple's localized string.
+        if product.priceFormatStyle.currencyCode == "USD", product.price < 1 {
+            let cents = NSDecimalNumber(decimal: product.price * 100).intValue
+            return "\(cents)¢"
+        }
+
+        return product.displayPrice
     }
 
     @ObservationIgnored private var updatesTask: Task<Void, Never>?
 
     init() {
+        // Start from the last verified entitlement so the UI doesn't flash the
+        // non-supporter state while StoreKit checks current entitlements.
+        currentTier = Defaults[.cachedSupporterTier].flatMap(SupporterTier.init(rawValue:))
+
         // Transactions can arrive outside a purchase flow (renewals, Ask to Buy
         // approvals, purchases on another device). Finish them and refresh.
         updatesTask = Task { [weak self] in
@@ -142,6 +158,7 @@ final class SupporterStore {
         }
 
         currentTier = active
+        Defaults[.cachedSupporterTier] = active?.rawValue
     }
 
     func purchase(_ tier: SupporterTier, source: String) async {

--- a/Luka/Views/SupportBannerView.swift
+++ b/Luka/Views/SupportBannerView.swift
@@ -55,6 +55,6 @@ struct SupportBannerView: View {
 }
 
 #Preview {
-    SupportBannerView(displayPrice: "$1.99", onTap: {}, onDismiss: {})
+    SupportBannerView(displayPrice: "99¢", onTap: {}, onDismiss: {})
         .padding()
 }

--- a/Luka/Views/SupportView.swift
+++ b/Luka/Views/SupportView.swift
@@ -231,39 +231,23 @@ private struct TierRow: View {
                     .frame(width: 28)
 
                 VStack(alignment: .leading, spacing: .spacing1) {
-                    // Name and badge sit side by side, but stack once the
-                    // text is too large to share a line.
-                    let nameLayout = isAccessibilitySize
-                        ? AnyLayout(VStackLayout(alignment: .leading, spacing: .spacing1))
-                        : AnyLayout(HStackLayout(spacing: .spacing4))
-
-                    nameLayout {
-                        Text(tier.name)
-                            .font(.headline)
-
-                        if isCurrent {
-                            Text("Current")
-                                .font(.caption2.weight(.semibold))
-                                .padding(.horizontal, .spacing4)
-                                .padding(.vertical, .spacing1)
-                                .background(.accent.opacity(0.15), in: .capsule)
-                                .foregroundStyle(.accent)
-                        }
-                    }
+                    Text(tier.name)
+                        .font(.headline)
 
                     Text(tier.description)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
 
                     if isAccessibilitySize {
-                        price.padding(.top, .spacing1)
+                        priceColumn(alignment: .leading)
+                            .padding(.top, .spacing1)
                     }
                 }
                 .multilineTextAlignment(.leading)
 
                 if !isAccessibilitySize {
                     Spacer(minLength: .spacing4)
-                    price
+                    priceColumn(alignment: .trailing)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -278,10 +262,22 @@ private struct TierRow: View {
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
-    private var price: some View {
-        Text("\(displayPrice)/mo")
-            .font(.subheadline.weight(.semibold))
-            .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+    /// The price, with the Current badge beneath it for the active tier.
+    private func priceColumn(alignment: HorizontalAlignment) -> some View {
+        VStack(alignment: alignment, spacing: .spacing1) {
+            Text("\(displayPrice)/mo")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+
+            if isCurrent {
+                Text("Current")
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, .spacing4)
+                    .padding(.vertical, .spacing1)
+                    .background(.accent.opacity(0.15), in: .capsule)
+                    .foregroundStyle(.accent)
+            }
+        }
     }
 }
 

--- a/Shared/Utilities/Defaults.swift
+++ b/Shared/Utilities/Defaults.swift
@@ -54,6 +54,9 @@ extension Defaults.Keys {
     static let liveActivityStartCount = Key<Int>("liveActivityStartCount", default: 0, suite: .shared, iCloud: true)
     static let supportBannerDismissed = Key<Bool>("supportBannerDismissed", default: false, suite: .shared, iCloud: true)
     static let lastSupportPromptDate = Key<Date?>("lastSupportPromptDate", default: nil, suite: .shared, iCloud: true)
+    // Device-local cache of the last verified supporter tier (product ID), so the
+    // app doesn't flash the support banner at launch before StoreKit answers.
+    static let cachedSupporterTier = Key<String?>("cachedSupporterTier", default: nil, suite: .shared)
 }
 
 extension AccountLocation: Defaults.Serializable {}


### PR DESCRIPTION
## Summary
- Supporter tiers are now 99¢ / $2.99 / $9.99 per month. App Store Connect prices were already changed and equalized across territories; this updates the local StoreKit config, the fallback display prices, and the tier table in CLAUDE.md to match.
- Sub-dollar US prices are formatted as cents ("99¢") rather than "$0.99". Other storefronts keep Apple's localized string.
- New tier subtitles: "Cheap but fast-acting." / "A classic." / "You're overtreating, but we're here for it."
- The Current badge sits beneath the price instead of beside the tier name.
- The last verified supporter tier is cached in a device-local Defaults key and used to seed `SupporterStore` at launch, so supporters no longer see the support banner flash before StoreKit reports entitlements. Every entitlement refresh writes the cache back, including nil on lapse.

## Test plan
- [x] Rendered the support sheet and tier rows at Large and AX 3, light and dark
- [x] Verified resolved ASC prices for US, GB, DE, JP on all three subscriptions
- [x] Luka scheme builds for iPhone 17 Pro simulator
- [ ] On a device with an active sandbox subscription, relaunch and confirm the banner does not flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)