### PR TITLE
Remove leftover Bluetooth Info.plist keys

### DIFF
--- a/Luka/Info.plist
+++ b/Luka/Info.plist
@@ -4,15 +4,9 @@
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>Luka can connect directly to your Dexcom G7 sensor to show its readings.</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
 	<true/>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>bluetooth-central</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Removes `NSBluetoothAlwaysUsageDescription` and the `UIBackgroundModes` array (which only contained `bluetooth-central`) from `Luka/Info.plist`. These were left behind when Direct to G7 was torn out in #123; no CoreBluetooth code or DexcomKit dependency remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoVFKuX7asjowpT9wRpzvu