### PR TITLE
Add TelemetryDeck signals for push-to-start restart diagnosis

### DIFF
--- a/Luka.xcodeproj/project.pbxproj
+++ b/Luka.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 				Models/DexcomClientService.swift,
 				Models/DexcomDelegate.swift,
 				Models/DexcomHelper.swift,
+				Models/ClientEventRequest.swift,
 				Models/EndLiveActivityRequest.swift,
 				Models/GlucoseReadingsCache.swift,
 				Models/LiveActivityState.swift,

--- a/Luka/ClientEventReporter.swift
+++ b/Luka/ClientEventReporter.swift
@@ -1,0 +1,102 @@
+//
+//  ClientEventReporter.swift
+//  Luka
+//
+//  Created by Claude on 9/12/26.
+//
+
+import Defaults
+import Foundation
+import KeychainAccess
+import UIKit
+
+extension Defaults.Keys {
+    // Device-local queue of Live Activity lifecycle observations not yet posted to the
+    // server. Persisted so a background wake that gets suspended before its upload
+    // finishes doesn't lose what it saw. Lives here (app target only) because the shared
+    // Defaults file is compiled by targets that don't include the request model.
+    static let pendingClientEvents = Key<[ClientEventRequest.Event]>("pendingClientEvents", default: [], suite: .shared)
+}
+
+/// Records Live Activity lifecycle observations and ships them to the server in batches.
+///
+/// Events are appended to a persisted queue first, so an observation made during a short
+/// background wake survives even if the process is suspended before the upload finishes;
+/// it goes out with the next batch. A flush is debounced briefly so the burst of events
+/// from one wake (activity observed → token received → registered) becomes one request,
+/// and runs under a background task assertion so it completes after the app leaves the
+/// foreground.
+@MainActor
+final class ClientEventReporter {
+    private static let maxQueued = 200
+    private static let flushDelay: Duration = .seconds(1.5)
+
+    private let client = HTTPClient()
+    private var flushTask: Task<Void, Never>?
+
+    func record(_ name: String, activityID: String? = nil, _ attributes: [String: String] = [:]) {
+        let event = ClientEventRequest.Event(
+            name: name,
+            occurredAt: Date.now.timeIntervalSince1970,
+            activityID: activityID,
+            attributes: attributes.isEmpty ? nil : attributes
+        )
+        var queued = Defaults[.pendingClientEvents]
+        queued.append(event)
+        if queued.count > Self.maxQueued {
+            queued.removeFirst(queued.count - Self.maxQueued)
+        }
+        Defaults[.pendingClientEvents] = queued
+        scheduleFlush()
+    }
+
+    func flushNow() async {
+        flushTask?.cancel()
+        flushTask = nil
+        await flush()
+    }
+
+    private func scheduleFlush() {
+        guard flushTask == nil else { return }
+        flushTask = Task {
+            try? await Task.sleep(for: Self.flushDelay)
+            guard !Task.isCancelled else { return }
+            flushTask = nil
+            await flush()
+        }
+    }
+
+    private func flush() async {
+        // Only the signed-in username makes an event attributable; without one, keep the
+        // queue for a later flush after sign-in.
+        guard let username = Keychain.shared.username, username != DexcomHelper.mockEmail else { return }
+        let batch = Defaults[.pendingClientEvents]
+        guard !batch.isEmpty else { return }
+
+        let payload = ClientEventRequest(
+            username: username,
+            systemVersion: UIDevice.current.systemVersion,
+            deviceModel: Self.deviceModel,
+            events: batch
+        )
+
+        await client.withBackgroundTask(name: "LiveActivity.clientEvents") {
+            do {
+                let request = try client.makePostRequest("client-event", body: payload)
+                try await client.send(request)
+                // Drop exactly what was sent; anything recorded mid-flight stays queued.
+                Defaults[.pendingClientEvents].removeAll { batch.contains($0) }
+            } catch {
+                // Leave the queue intact for the next flush.
+            }
+        }
+    }
+
+    private static let deviceModel: String = {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        return withUnsafePointer(to: &systemInfo.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) { String(cString: $0) }
+        }
+    }()
+}

--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -251,7 +251,12 @@ final class LiveActivityManager {
         await client.withBackgroundTask(name: "LiveActivity.sendStartLiveActivity") {
             do {
                 let request = try client.makePostRequest("start-live-activity", body: payload)
-                try await client.send(request)
+                let (_, response) = try await client.send(request)
+                // A 4xx/5xx is a failed registration: the server has no token and will
+                // never push to this activity. Treat it as an error instead of a success.
+                guard (200..<300).contains(response.statusCode) else {
+                    throw HTTPClient.StatusError(statusCode: response.statusCode)
+                }
                 TelemetryDeck.signal(
                     "LiveActivity.sentToken",
                     parameters: ["kind": kind, "pushToStart": String(pushToStart), "restartEnabled": String(restartEnabled)]
@@ -343,7 +348,10 @@ final class LiveActivityManager {
         await client.withBackgroundTask(name: "LiveActivity.sendEndLiveActivity") {
             do {
                 let request = try client.makePostRequest("end-live-activity", body: payload)
-                try await client.send(request)
+                let (_, response) = try await client.send(request)
+                guard (200..<300).contains(response.statusCode) else {
+                    throw HTTPClient.StatusError(statusCode: response.statusCode)
+                }
                 TelemetryDeck.signal("LiveActivity.sentEnd")
                 reporter.record("end_sent", activityID: activityID)
             } catch {

--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -19,6 +19,7 @@ final class LiveActivityManager {
     static let shared = LiveActivityManager()
 
     private let client = HTTPClient()
+    private let reporter = ClientEventReporter()
 
     private var observationTasks: [String: Task<Void, Never>] = [:]
     private var activityTokens: [String: String] = [:]
@@ -26,8 +27,21 @@ final class LiveActivityManager {
     private var pushToStartTask: Task<Void, Never>?
 
     private init() {
+        // First thing on any launch: did we come up at all, and in what state? For a
+        // push-to-start restart the system is supposed to wake the app in the background;
+        // an `app_launch` in the server's telemetry shortly after its `push_started` is
+        // the proof, and its absence is the finding.
+        let existing = Activity<ReadingAttributes>.activities
+        reporter.record("app_launch", [
+            "app_state": Self.describe(UIApplication.shared.applicationState),
+            "activities": String(existing.count),
+            "protected_data": String(UIApplication.shared.isProtectedDataAvailable),
+            "restart_enabled": String(Defaults[.autoRestartLiveActivity]),
+            "has_pts_token": String(Defaults[.pushToStartToken] != nil),
+        ])
+
         // Observe existing activities
-        for activity in Activity<ReadingAttributes>.activities {
+        for activity in existing {
             observeActivity(activity, source: "existing")
         }
 
@@ -57,6 +71,11 @@ final class LiveActivityManager {
             for await data in Activity<ReadingAttributes>.pushToStartTokenUpdates {
                 let token = data.map { String(format: "%02x", $0) }.joined()
                 let changed = token != Defaults[.pushToStartToken]
+                reporter.record("push_to_start_token", [
+                    "changed": String(changed),
+                    "had_token": String(Defaults[.pushToStartToken] != nil),
+                    "pts_prefix": String(token.prefix(8)),
+                ])
                 // Every yield is signalled, changed or not: if the server keeps pushing to
                 // a token this device no longer reports, the mismatch shows up here.
                 TelemetryDeck.signal(
@@ -72,6 +91,21 @@ final class LiveActivityManager {
                 await reregisterRunningActivities()
             }
         }
+    }
+
+    private static func describe(_ state: UIApplication.State) -> String {
+        switch state {
+        case .active: "active"
+        case .inactive: "inactive"
+        case .background: "background"
+        @unknown default: "unknown"
+        }
+    }
+
+    /// Ships any queued client events now — called on foreground so observations from a
+    /// wake that was suspended before its upload finished don't wait for the next event.
+    func flushClientEvents() async {
+        await reporter.flushNow()
     }
 
     func syncState(excluding excludedID: String? = nil) {
@@ -94,6 +128,12 @@ final class LiveActivityManager {
                 "state": String(describing: activity.activityState),
             ]
         )
+        reporter.record("activity_observed", activityID: activity.id, [
+            "source": source,
+            "push_to_start": String(activity.content.state.ps == true),
+            "state": String(describing: activity.activityState),
+            "reason": activity.content.state.r ?? "",
+        ])
 
         let stateTask = Task {
             for await state in activity.activityStateUpdates {
@@ -107,6 +147,11 @@ final class LiveActivityManager {
                             "hadToken": String(activityTokens[activity.id] != nil),
                         ]
                     )
+                    reporter.record("activity_ended", activityID: activity.id, [
+                        "state": String(describing: state),
+                        "push_to_start": String(activity.content.state.ps == true),
+                        "had_token": String(activityTokens[activity.id] != nil),
+                    ])
                     observationTasks.removeValue(forKey: activity.id)
                     activityTokens.removeValue(forKey: activity.id)
                     // Dismissal happens while the app is backgrounded (you're on the Lock
@@ -136,12 +181,17 @@ final class LiveActivityManager {
             for await token in activity.pushTokenUpdates {
                 let tokenString = token.map { String(format: "%02x", $0) }.joined()
                 let kind: String = activityTokens[activity.id] == nil ? "initial" : "update"
-                let pushToStart = String(activity.content.state.ps == true)
+                let pushToStart = activity.content.state.ps == true
                 activityTokens[activity.id] = tokenString
                 TelemetryDeck.signal(
                     "LiveActivity.receivedToken",
-                    parameters: ["kind": kind, "pushToStart": pushToStart]
+                    parameters: ["kind": kind, "pushToStart": String(pushToStart)]
                 )
+                reporter.record("token_received", activityID: activity.id, [
+                    "kind": kind,
+                    "push_to_start": String(pushToStart),
+                    "token_prefix": String(tokenString.prefix(8)),
+                ])
                 await sendStartLiveActivity(
                     activityID: activity.id, token: tokenString, kind: kind, pushToStart: pushToStart
                 )
@@ -156,12 +206,21 @@ final class LiveActivityManager {
     }
 
     private func sendStartLiveActivity(
-        activityID: String, token: String, kind: String, pushToStart: String = "false"
+        activityID: String, token: String, kind: String, pushToStart: Bool = false
     ) async {
         guard let username = Keychain.shared.username,
               let password = Keychain.shared.password,
               let accountLocation = Defaults[.accountLocation],
               username != DexcomHelper.mockEmail else {
+            // A silent return here is exactly the kind of gap that hides a failed restart
+            // registration; the queue is flushed once credentials are readable.
+            reporter.record("token_send_skipped", activityID: activityID, [
+                "kind": kind,
+                "push_to_start": String(pushToStart),
+                "has_username": String(Keychain.shared.username != nil),
+                "has_password": String(Keychain.shared.password != nil),
+                "has_location": String(Defaults[.accountLocation] != nil),
+            ])
             return
         }
 
@@ -185,7 +244,8 @@ final class LiveActivityManager {
             ),
             pushToStartToken: restartEnabled ? Defaults[.pushToStartToken] : nil,
             attributesType: restartEnabled ? "ReadingAttributes" : nil,
-            attributes: restartEnabled ? try? JSONValue(encoding: ReadingAttributes(range: range)) : nil
+            attributes: restartEnabled ? try? JSONValue(encoding: ReadingAttributes(range: range)) : nil,
+            pushToStart: pushToStart
         )
 
         await client.withBackgroundTask(name: "LiveActivity.sendStartLiveActivity") {
@@ -194,13 +254,19 @@ final class LiveActivityManager {
                 try await client.send(request)
                 TelemetryDeck.signal(
                     "LiveActivity.sentToken",
-                    parameters: ["kind": kind, "pushToStart": pushToStart, "restartEnabled": String(restartEnabled)]
+                    parameters: ["kind": kind, "pushToStart": String(pushToStart), "restartEnabled": String(restartEnabled)]
                 )
+                reporter.record("token_sent", activityID: activityID, [
+                    "kind": kind, "push_to_start": String(pushToStart), "restart_enabled": String(restartEnabled),
+                ])
             } catch {
                 TelemetryDeck.signal(
                     "LiveActivity.failedToSendToken",
-                    parameters: ["kind": kind, "pushToStart": pushToStart, "error": String(describing: type(of: error))]
+                    parameters: ["kind": kind, "pushToStart": String(pushToStart), "error": String(describing: type(of: error))]
                 )
+                reporter.record("token_send_failed", activityID: activityID, [
+                    "kind": kind, "push_to_start": String(pushToStart), "error": String(describing: error).prefix(120).description,
+                ])
             }
         }
     }
@@ -279,8 +345,12 @@ final class LiveActivityManager {
                 let request = try client.makePostRequest("end-live-activity", body: payload)
                 try await client.send(request)
                 TelemetryDeck.signal("LiveActivity.sentEnd")
+                reporter.record("end_sent", activityID: activityID)
             } catch {
                 TelemetryDeck.signal("LiveActivity.failedToSendEnd")
+                reporter.record("end_send_failed", activityID: activityID, [
+                    "error": String(describing: error).prefix(120).description,
+                ])
             }
         }
     }

--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -28,7 +28,7 @@ final class LiveActivityManager {
     private init() {
         // Observe existing activities
         for activity in Activity<ReadingAttributes>.activities {
-            observeActivity(activity)
+            observeActivity(activity, source: "existing")
         }
 
         syncState()
@@ -36,7 +36,7 @@ final class LiveActivityManager {
         // Observe new activities as they're created
         activityUpdatesTask = Task {
             for await activity in Activity<ReadingAttributes>.activityUpdates {
-                observeActivity(activity)
+                observeActivity(activity, source: "updates")
                 syncState()
             }
         }
@@ -56,7 +56,18 @@ final class LiveActivityManager {
         pushToStartTask = Task {
             for await data in Activity<ReadingAttributes>.pushToStartTokenUpdates {
                 let token = data.map { String(format: "%02x", $0) }.joined()
-                guard token != Defaults[.pushToStartToken] else { continue }
+                let changed = token != Defaults[.pushToStartToken]
+                // Every yield is signalled, changed or not: if the server keeps pushing to
+                // a token this device no longer reports, the mismatch shows up here.
+                TelemetryDeck.signal(
+                    "LiveActivity.pushToStartTokenUpdated",
+                    parameters: [
+                        "changed": String(changed),
+                        "hadToken": String(Defaults[.pushToStartToken] != nil),
+                        "runningActivities": String(Activity<ReadingAttributes>.activities.count),
+                    ]
+                )
+                guard changed else { continue }
                 Defaults[.pushToStartToken] = token
                 await reregisterRunningActivities()
             }
@@ -68,13 +79,34 @@ final class LiveActivityManager {
         ControlCenter.shared.reloadAllControls()
     }
 
-    private func observeActivity(_ activity: Activity<ReadingAttributes>) {
+    private func observeActivity(_ activity: Activity<ReadingAttributes>, source: String) {
         guard observationTasks[activity.id] == nil else { return }
+
+        // The server marks push-to-start-launched content with `ps`, so this is the
+        // device-side proof that a 7-hour restart actually produced an activity. A
+        // `push_started` on the server with no `pushToStart: true` observation here means
+        // iOS dropped the start push (or never launched us for it).
+        TelemetryDeck.signal(
+            "LiveActivity.activityObserved",
+            parameters: [
+                "source": source,
+                "pushToStart": String(activity.content.state.ps == true),
+                "state": String(describing: activity.activityState),
+            ]
+        )
 
         let stateTask = Task {
             for await state in activity.activityStateUpdates {
                 switch state {
                 case .dismissed, .ended:
+                    TelemetryDeck.signal(
+                        "LiveActivity.activityEnded",
+                        parameters: [
+                            "state": String(describing: state),
+                            "pushToStart": String(activity.content.state.ps == true),
+                            "hadToken": String(activityTokens[activity.id] != nil),
+                        ]
+                    )
                     observationTasks.removeValue(forKey: activity.id)
                     activityTokens.removeValue(forKey: activity.id)
                     // Dismissal happens while the app is backgrounded (you're on the Lock
@@ -104,9 +136,15 @@ final class LiveActivityManager {
             for await token in activity.pushTokenUpdates {
                 let tokenString = token.map { String(format: "%02x", $0) }.joined()
                 let kind: String = activityTokens[activity.id] == nil ? "initial" : "update"
+                let pushToStart = String(activity.content.state.ps == true)
                 activityTokens[activity.id] = tokenString
-                TelemetryDeck.signal("LiveActivity.receivedToken", parameters: ["kind": kind])
-                await sendStartLiveActivity(activityID: activity.id, token: tokenString, kind: kind)
+                TelemetryDeck.signal(
+                    "LiveActivity.receivedToken",
+                    parameters: ["kind": kind, "pushToStart": pushToStart]
+                )
+                await sendStartLiveActivity(
+                    activityID: activity.id, token: tokenString, kind: kind, pushToStart: pushToStart
+                )
             }
         }
 
@@ -117,7 +155,9 @@ final class LiveActivityManager {
         }
     }
 
-    private func sendStartLiveActivity(activityID: String, token: String, kind: String) async {
+    private func sendStartLiveActivity(
+        activityID: String, token: String, kind: String, pushToStart: String = "false"
+    ) async {
         guard let username = Keychain.shared.username,
               let password = Keychain.shared.password,
               let accountLocation = Defaults[.accountLocation],
@@ -152,9 +192,15 @@ final class LiveActivityManager {
             do {
                 let request = try client.makePostRequest("start-live-activity", body: payload)
                 try await client.send(request)
-                TelemetryDeck.signal("LiveActivity.sentToken", parameters: ["kind": kind])
+                TelemetryDeck.signal(
+                    "LiveActivity.sentToken",
+                    parameters: ["kind": kind, "pushToStart": pushToStart, "restartEnabled": String(restartEnabled)]
+                )
             } catch {
-                TelemetryDeck.signal("LiveActivity.failedToSendToken", parameters: ["kind": kind])
+                TelemetryDeck.signal(
+                    "LiveActivity.failedToSendToken",
+                    parameters: ["kind": kind, "pushToStart": pushToStart, "error": String(describing: type(of: error))]
+                )
             }
         }
     }

--- a/Luka/LukaApp.swift
+++ b/Luka/LukaApp.swift
@@ -58,6 +58,9 @@ struct LukaApp: App {
                 Task {
                     await supporterStore.refreshEntitlement()
                 }
+                Task {
+                    await liveActivityManager.flushClientEvents()
+                }
             }
         }
     }

--- a/Shared/Models/ClientEventRequest.swift
+++ b/Shared/Models/ClientEventRequest.swift
@@ -1,0 +1,27 @@
+//
+//  ClientEventRequest.swift
+//  Luka
+//
+//  Created by Claude on 9/12/26.
+//
+
+import Defaults
+import Foundation
+
+/// A batch of Live Activity lifecycle observations posted to `client-event`, so what the
+/// device saw lands in the server's telemetry next to what the server did — with the
+/// device's own timestamps, since a batch from a background wake can be sent later.
+struct ClientEventRequest: Codable {
+    struct Event: Codable, Defaults.Serializable, Equatable {
+        var name: String
+        /// Seconds since 1970 on the device clock, when the event happened.
+        var occurredAt: Double
+        var activityID: String?
+        var attributes: [String: String]?
+    }
+
+    var username: String
+    var systemVersion: String?
+    var deviceModel: String?
+    var events: [Event]
+}

--- a/Shared/Models/StartLiveActivityRequest.swift
+++ b/Shared/Models/StartLiveActivityRequest.swift
@@ -49,6 +49,11 @@ struct StartLiveActivityRequest: Codable {
     /// Stored as opaque JSON so this shared model stays decoupled from `ReadingAttributes`
     /// (which isn't a member of every target that compiles this file, e.g. the Watch).
     var attributes: JSONValue?
+
+    /// Whether the system started this activity from a push-to-start push (the
+    /// content-state `ps` flag), so the server can tell a late restart registration
+    /// from a fresh manual start.
+    var pushToStart: Bool?
 }
 
 /// A minimal, Foundation-only recursive JSON value. Lets the request carry the activity's

--- a/Shared/Utilities/HTTPClient.swift
+++ b/Shared/Utilities/HTTPClient.swift
@@ -11,6 +11,13 @@ import Foundation
 /// with the app version and build, so the server can correlate behavior
 /// with the client release.
 struct HTTPClient {
+    /// A non-2xx response, for callers that treat one as a failure. `send` itself does
+    /// not throw on status so callers that expect a 404 (the readings proxy) keep working.
+    struct StatusError: Error, CustomStringConvertible {
+        var statusCode: Int
+        var description: String { "HTTP \(statusCode)" }
+    }
+
     var baseURL: URL
     var session: URLSession
 


### PR DESCRIPTION
## Why

One device (mine) has dropped ~92% of 7-hour push-to-start restarts since Aug 29, against a fleet baseline of ~5%. The server sees APNs accept the start push, then nothing. Whether iOS woke the app, whether it launched the restarted activity, whether the app captured its token, and whether the registration reached the server were all invisible. TelemetryDeck alone can't answer this: its timestamps are server-receipt time and a background wake's signals often upload minutes later.

## What

**Client-event reporting** (`ClientEventReporter`, posts to the server's new `client-event` route, kylebshr/luka-vapor#79):

- `app_launch` (`app_state`, `activities`, `protected_data`, `restart_enabled`, `has_pts_token`) — recorded first thing in the manager's init. After a server `push_started`, this in `background` state is the proof iOS woke the app; its absence is the finding.
- `activity_observed` / `activity_ended` (`source`, `push_to_start` from the server's `ps` content flag, `state`).
- `token_received`, `token_sent`, `token_send_failed`, `token_send_skipped` (the previously silent credentials guard).
- `push_to_start_token` (`changed`, `had_token`, `pts_prefix`) on every yield of the stream.
- `end_sent` / `end_send_failed`.

Events go into a persisted queue (`Defaults[.pendingClientEvents]`) first, then flush as one debounced request under a background task assertion, so a wake that's suspended before upload doesn't lose what it saw. The queue also flushes on foreground. Each event carries the device timestamp; the server stamps upload lag and, when a restart push is pending, seconds since that push.

**TelemetryDeck signals** for fleet-level rates: `LiveActivity.activityObserved`, `pushToStartTokenUpdated`, `activityEnded`, plus `pushToStart` / `restartEnabled` / error type on the existing token signals.

**Start request** now carries `pushToStart` so the server can tell a late restart registration from a manual start.

**Registration failures are no longer silent.** `send` never threw on status, so a 4xx/5xx from `start-live-activity` counted as success and the app carried on with an activity the server would never push to. Start and end calls now require 2xx and report `token_send_failed` / `end_send_failed` with the status code otherwise.

No other behavior changes to the Live Activity flow itself.

## Testing

- Simulator build of the `Luka` scheme succeeds.
- `Shared/Models/ClientEventRequest.swift` is added to the Luka target's membership list in the project (the shared group is synced by the widget targets, so app-only shared files need the explicit entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)